### PR TITLE
[docs] A few small changes to intro to make it a bit more smooth

### DIFF
--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -35,9 +35,11 @@ Install `expo-router`:
 
 ```bash
 npx expo install expo-router
+```
 
-# install peer dependencies required for compiling
+Install peer dependencies:
 
+```
 npx expo install react-native-safe-area-context react-native-screens react-native-reanimated react-native-gesture-handler
 ```
 
@@ -48,6 +50,18 @@ Then use `expo-router/entry` as the entry point to your app in your `package.jso
   "main": "expo-router/entry"
 }
 ```
+
+And add a scheme to your `app.json` (or `app.config.js`):
+
+```json
+{
+  "expo": {
+    "scheme": "myapp"
+  }
+}
+```
+
+The following beta setup steps are required for now, but will not be necessary when we release a stable version of Expo Router.
 
 ## Beta setup
 
@@ -86,7 +100,7 @@ If you want to use the router with web, you'll need to enable Expo CLI's [experi
 Start the server with:
 
 ```
-yarn expo start
+npx expo start --clear
 ```
 
 Then open by pressing `i`, `a`, or `w` for web (only tested against Metro web).


### PR DESCRIPTION
- Move installing peer dependencies to a separate block, even though you could copy the entire block the way it is right now it feels a little awkward.
- Encourage people to add a scheme to their app config - if they don't, there are some annoying warnings from expo-linking which makes the first time experience feel less smooth.
- Recommend using the `--clear` flag with `npx expo start`, in case someone is running this in an existing project or they ran `npx expo start` already on the project and loaded it for some reason. Just a bit more foolproof. Also, change from yarn to npx here for consistency.