### PR TITLE
feat: useLink().replace()

### DIFF
--- a/docs/docs/features/linking.md
+++ b/docs/docs/features/linking.md
@@ -53,6 +53,7 @@ Prefer the `useLink` hook to `useNavigation` from React Navigation as `useLink` 
 ## `useLink` API
 
 - **push**: _`(href: Href) => void`_ Navigate to a route. You can provide a full path like `/profile/settings` or a relative path like `../settings`. Navigate to dynamic routes by passing an object like `{ pathname: 'profile', query: { id: '123' } }`.
+- **replace**: _`(href: Href) => void`_ Same API as `push` but replaces the current route in the history instead of pushing a new one. This is useful for redirects.
 - **back**: _`() => void`_ Navigate to a route. You can provide a full path like `/profile/settings` or a relative path like `../settings`. Navigate to dynamic routes by passing an object like `{ pathname: 'profile', query: { id: '123' } }`.
 
 > This API is similar to Next.js's `useRouter` hook, but adjusted to work around the state management requirements of native.

--- a/packages/expo-router/src/fork/useLinkToPath.ts
+++ b/packages/expo-router/src/fork/useLinkToPath.ts
@@ -1,0 +1,61 @@
+import {
+  getActionFromState,
+  getStateFromPath,
+  NavigationContainerRefContext,
+} from "@react-navigation/core";
+import * as React from "react";
+import { Linking } from "react-native";
+
+import { LinkingContext } from "@react-navigation/native";
+
+export function useLinkToPath() {
+  const navigation = React.useContext(NavigationContainerRefContext);
+  const linking = React.useContext(LinkingContext);
+
+  const linkTo = React.useCallback(
+    (to: string, event?: string) => {
+      if (navigation === undefined) {
+        throw new Error(
+          "Couldn't find a navigation object. Is your component inside NavigationContainer?"
+        );
+      }
+
+      if (!to.startsWith("/")) {
+        if (/:\/\//.test(to)) {
+          // Open external link
+          Linking.openURL(to);
+          return;
+        } else {
+          throw new Error(
+            `The href must start with '/' (${to}) or be a fully qualified URL.`
+          );
+        }
+      }
+
+      const { options } = linking;
+
+      const state = options?.getStateFromPath
+        ? options.getStateFromPath(to, options.config)
+        : getStateFromPath(to, options?.config);
+
+      if (state) {
+        const action = getActionFromState(state, options?.config);
+
+        if (action !== undefined) {
+          if (event) {
+            // @ts-ignore
+            action.type = event;
+          }
+          navigation.dispatch(action);
+        } else {
+          navigation.reset(state);
+        }
+      } else {
+        throw new Error("Failed to parse the path to a navigation state.");
+      }
+    },
+    [linking, navigation]
+  );
+
+  return linkTo;
+}

--- a/packages/expo-router/src/fork/useLinkToPath.ts
+++ b/packages/expo-router/src/fork/useLinkToPath.ts
@@ -3,10 +3,9 @@ import {
   getStateFromPath,
   NavigationContainerRefContext,
 } from "@react-navigation/core";
+import { LinkingContext } from "@react-navigation/native";
 import * as React from "react";
 import { Linking } from "react-native";
-
-import { LinkingContext } from "@react-navigation/native";
 
 export function useLinkToPath() {
   const navigation = React.useContext(NavigationContainerRefContext);

--- a/packages/expo-router/src/useLink.ts
+++ b/packages/expo-router/src/useLink.ts
@@ -1,8 +1,8 @@
 import { useNavigation } from "@react-navigation/native";
 import { useMemo } from "react";
 
-import { Href, resolveHref } from "./views/Link";
 import { useLinkToPath } from "./fork/useLinkToPath";
+import { Href, resolveHref } from "./views/Link";
 
 // Wraps useLinkTo to provide an API which is similar to the Link component.
 export function useLink(): {

--- a/packages/expo-router/src/useLink.ts
+++ b/packages/expo-router/src/useLink.ts
@@ -1,15 +1,17 @@
-import { useLinkTo, useNavigation } from "@react-navigation/native";
+import { useNavigation } from "@react-navigation/native";
 import { useMemo } from "react";
 
 import { Href, resolveHref } from "./views/Link";
+import { useLinkToPath } from "./fork/useLinkToPath";
 
 // Wraps useLinkTo to provide an API which is similar to the Link component.
 export function useLink(): {
   push: (href: Href) => void;
+  replace: (href: Href) => void;
   back: () => void;
   parse: typeof resolveHref;
 } {
-  const linkTo = useLinkTo();
+  const linkTo = useLinkToPath();
   const navigation = useNavigation();
 
   return useMemo(
@@ -18,9 +20,13 @@ export function useLink(): {
         const href = resolveHref(url);
         linkTo(href);
       },
+      replace: (url: Href) => {
+        const href = resolveHref(url);
+        linkTo(href, "REPLACE");
+      },
       back: () => navigation?.goBack(),
       parse: resolveHref,
-      // TODO(EvanBacon): add `replace`, `pathname`, `query`, maybe `reload`
+      // TODO(EvanBacon): add `pathname`, `query`, maybe `reload`
       // TODO(EvanBacon): add `canGoBack` but maybe more like a `hasContext`
     }),
     [navigation, linkTo]


### PR DESCRIPTION
Add support for replacing the screen with another, this will make render-blocking and redirecting possible.

Related:
- https://github.com/expo/router/discussions/20
- https://github.com/expo/router/issues/14