### PR TITLE
fix demo app secondary try

### DIFF
--- a/apps/demo/app/(root)/(tab)/index.js
+++ b/apps/demo/app/(root)/(tab)/index.js
@@ -1,4 +1,4 @@
-import { Link, useLink, NativeStack, Tabs } from "expo-router";
+import { Link, useLink, Tabs } from "expo-router";
 import { StatusBar, StyleSheet, Text, View } from "react-native";
 
 export default function Page() {
@@ -7,7 +7,7 @@ export default function Page() {
     <View style={styles.container}>
       <Tabs.Screen options={{ title: "Home" }} />
       <Link
-        href={{ pathname: "/settings/[home]", query: { home: "baconbrix" } }}
+        href={"/modal"}
         style={{ fontSize: 24, fontWeight: "bold" }}
       >
         Open Modal

--- a/apps/demo/app/(root)/modal.tsx
+++ b/apps/demo/app/(root)/modal.tsx
@@ -6,21 +6,24 @@ export default function App({ navigation }) {
 
   return (
     <View style={styles.container}>
-      <Link href="../" style={{ fontSize: 24, fontWeight: "bold" }}>
+      <Link to="../" style={{ fontSize: 24, fontWeight: "bold" }}>
         Dismiss
       </Link>
       <Text
         onPress={() => {
-          link.back();
+            link.push({
+                pathname: "/settings/[home]",
+                query: { home: "baconbrix" },
+            });
         }}
       >
         Open settings dynamic
       </Text>
       <StatusBar barStyle="light-content" />
       {navigation.canGoBack() ? (
-        <span>Can go back</span>
+        <Text>Can go back</Text>
       ) : (
-        <span>Can't go back</span>
+        <Text>Can't go back</Text>
       )}
     </View>
   );

--- a/apps/demo/app/(root)/modal.tsx
+++ b/apps/demo/app/(root)/modal.tsx
@@ -6,7 +6,7 @@ export default function App({ navigation }) {
 
   return (
     <View style={styles.container}>
-      <Link to="../" style={{ fontSize: 24, fontWeight: "bold" }}>
+      <Link href="../" style={{ fontSize: 24, fontWeight: "bold" }}>
         Dismiss
       </Link>
       <Text

--- a/apps/demo/metro.config.js
+++ b/apps/demo/metro.config.js
@@ -1,5 +1,5 @@
 // Learn more https://docs.expo.io/guides/customizing-metro
-const { getDefaultConfig } = require("expo-router/metro-config");
+const { getDefaultConfig } = require("expo/metro-config");
 const path = require("path");
 
 // Find the project and workspace directories
@@ -18,5 +18,10 @@ config.resolver.nodeModulesPaths = [
 ];
 // 3. Force Metro to resolve (sub)dependencies only from the `nodeModulesPaths`
 config.resolver.disableHierarchicalLookup = true;
+
+// 4. `require.context` support
+config.transformer = {
+  unstable_allowRequireContext: true,
+};
 
 module.exports = config;

--- a/apps/demo/metro.config.js
+++ b/apps/demo/metro.config.js
@@ -19,9 +19,4 @@ config.resolver.nodeModulesPaths = [
 // 3. Force Metro to resolve (sub)dependencies only from the `nodeModulesPaths`
 config.resolver.disableHierarchicalLookup = true;
 
-// 4. `require.context` support
-config.transformer = {
-  unstable_allowRequireContext: true,
-};
-
 module.exports = config;


### PR DESCRIPTION
-- fix require `expo-router/metro-config` to `expo/metro-config`
-- add `config.transformer.unstable_allowRequireContext = true` to metro config
-- fix `Open Modal` link
-- fix `<Link href="../"` to `<Link to="../"`
-- fix `Open settings dynamic` in modal link
-- `<span>` to `<Text>` component in modal

now with true format )
p.s. without `config.transformer.unstable_allowRequireContext = true` in metro app doesnt run. i get code from https://github.com/EvanBacon/Metro-Context-Modules-Demo