### PR TITLE
feat: add statePath and normalized pathname to custom layouts

### DIFF
--- a/apps/demo/app/(root).tsx
+++ b/apps/demo/app/(root).tsx
@@ -1,20 +1,15 @@
-import { NativeStack } from "expo-router";
+import { Children, Layout, NativeStack } from "expo-router";
 
-export default function Layout() {
+export default function Root() {
   return (
-    <NativeStack>
-      <NativeStack.Screen
-        name="(tab)"
-        options={{
-          headerShown: false,
-        }}
-      />
-      <NativeStack.Screen
-        name="modal"
-        options={{
-          presentation: "modal",
-        }}
-      />
-    </NativeStack>
+    <Layout>
+      <Inner />
+    </Layout>
   );
+}
+function Inner() {
+  const { pathname, statePath } = Layout.useContext();
+
+  console.log("pathname", pathname, statePath);
+  return <Children />;
 }

--- a/apps/demo/app/(root)/[foo].tsx
+++ b/apps/demo/app/(root)/[foo].tsx
@@ -1,0 +1,36 @@
+import { Link, useLink } from "expo-router";
+import { StatusBar, StyleSheet, Text, View } from "react-native";
+
+export default function App({ navigation }) {
+  const link = useLink();
+
+  return (
+    <View style={styles.container}>
+      <Link href="../" style={{ fontSize: 24, fontWeight: "bold" }}>
+        Dismiss
+      </Link>
+      <Text
+        onPress={() => {
+          link.back();
+        }}
+      >
+        Open settings dynamic
+      </Text>
+      <StatusBar barStyle="light-content" />
+      {navigation.canGoBack() ? (
+        <span>Can go back</span>
+      ) : (
+        <span>Can't go back</span>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 20,
+    backgroundColor: "#fff",
+    alignItems: "center",
+  },
+});


### PR DESCRIPTION
Make it possible to easily determine which path is currently selected:

```tsx
import { Layout, Children } from 'expo-router';

function Root() {
  return <Layout><Inner /></Layout>
}

function Inner() {
  // Changes with normalized strings for identifying the selected route.
  const { pathname, statePath } = Layout.useContext();

  return <Children />
}
```