### PR TITLE
add `RootContainer.getRef()` function for accessing the navigation cotainer

### DIFF
--- a/docs/docs/features/container.md
+++ b/docs/docs/features/container.md
@@ -20,6 +20,15 @@ export default function Page() {
 }
 ```
 
+Access the [`<NavigationContainer />`](https://reactnavigation.org/docs/navigation-container/) ref with the `RootContainer.getRef()` function.
+
+```tsx title=app/home.tsx
+function Page() {
+  const navigationRef = RootContainer.getRef();
+  return <>...</>;
+}
+```
+
 > Avoid setting `children` or `linking` as these will break all automatic assumptions made by the router.
 
 - Avoid using [`initialState`](https://reactnavigation.org/docs/navigation-container/#initialstate) as this is automatically handled by deep links (which Expo Router enables by default).

--- a/packages/expo-router/src/ContextNavigationContainer.tsx
+++ b/packages/expo-router/src/ContextNavigationContainer.tsx
@@ -1,14 +1,15 @@
 import {
+  createNavigationContainerRef,
   findFocusedRoute,
   NavigationContainer,
-  NavigationContainerRef,
-  ParamListBase,
 } from "@react-navigation/native";
 import React, { useCallback } from "react";
 
 import { useLinkingConfig } from "./getLinkingConfig";
 import SplashModule from "./splash";
 import { VirtualRouteContext } from "./useCurrentRoute";
+
+const navigationRef = createNavigationContainerRef()
 
 type NavigationContainerProps = React.ComponentProps<
   typeof NavigationContainer
@@ -32,8 +33,7 @@ export function useNavigationContainerContext() {
 }
 
 /** react-navigation `NavigationContainer` with automatic `linking` prop generated from the routes context. */
-export const ContextNavigationContainer = React.forwardRef(
-  (props: NavigationContainerProps, ref: NavigationContainerProps["ref"]) => {
+export function ContextNavigationContainer(props: NavigationContainerProps) {
     const [state, setState] = React.useState<Partial<NavigationContainerProps>>(
       {}
     );
@@ -52,11 +52,10 @@ export const ContextNavigationContainer = React.forwardRef(
           setState,
         ]}
       >
-        <InternalContextNavigationContainer ref={ref} />
+        <InternalContextNavigationContainer />
       </NavigationContainerContext.Provider>
     );
   }
-);
 
 function trimQuery(pathname: string): string {
   const queryIndex = pathname.indexOf("?");
@@ -66,8 +65,7 @@ function trimQuery(pathname: string): string {
   return pathname;
 }
 
-const InternalContextNavigationContainer = React.forwardRef(
-  (props: object, ref: NavigationContainerProps["ref"]) => {
+function InternalContextNavigationContainer(props: object) {
     const [contextProps] = useNavigationContainerContext();
     const [state, setState] = React.useState<{
       pathname: string | null;
@@ -86,13 +84,6 @@ const InternalContextNavigationContainer = React.forwardRef(
       },
       [setState]
     );
-
-    const navigationRef =
-      React.useRef<NavigationContainerRef<ParamListBase>>(null);
-
-    React.useImperativeHandle(ref, () => navigationRef.current!, [
-      navigationRef,
-    ]);
 
     return (
       <VirtualRouteContext.Provider value={state}>
@@ -152,4 +143,9 @@ export function RootContainer({
   ]);
 
   return null;
+}
+
+/** Get the root navigation container ref. */
+RootContainer.getRef = () => {
+  return navigationRef;
 }

--- a/packages/expo-router/src/ContextNavigationContainer.tsx
+++ b/packages/expo-router/src/ContextNavigationContainer.tsx
@@ -9,7 +9,7 @@ import { useLinkingConfig } from "./getLinkingConfig";
 import SplashModule from "./splash";
 import { VirtualRouteContext } from "./useCurrentRoute";
 
-const navigationRef = createNavigationContainerRef()
+const navigationRef = createNavigationContainerRef();
 
 type NavigationContainerProps = React.ComponentProps<
   typeof NavigationContainer
@@ -34,28 +34,28 @@ export function useNavigationContainerContext() {
 
 /** react-navigation `NavigationContainer` with automatic `linking` prop generated from the routes context. */
 export function ContextNavigationContainer(props: NavigationContainerProps) {
-    const [state, setState] = React.useState<Partial<NavigationContainerProps>>(
-      {}
-    );
+  const [state, setState] = React.useState<Partial<NavigationContainerProps>>(
+    {}
+  );
 
-    const linking = useLinkingConfig();
-    console.log("linking", linking);
+  const linking = useLinkingConfig();
+  console.log("linking", linking);
 
-    return (
-      <NavigationContainerContext.Provider
-        value={[
-          {
-            ...props,
-            linking,
-            ...state,
-          },
-          setState,
-        ]}
-      >
-        <InternalContextNavigationContainer />
-      </NavigationContainerContext.Provider>
-    );
-  }
+  return (
+    <NavigationContainerContext.Provider
+      value={[
+        {
+          ...props,
+          linking,
+          ...state,
+        },
+        setState,
+      ]}
+    >
+      <InternalContextNavigationContainer />
+    </NavigationContainerContext.Provider>
+  );
+}
 
 function trimQuery(pathname: string): string {
   const queryIndex = pathname.indexOf("?");
@@ -66,47 +66,46 @@ function trimQuery(pathname: string): string {
 }
 
 function InternalContextNavigationContainer(props: object) {
-    const [contextProps] = useNavigationContainerContext();
-    const [state, setState] = React.useState<{
-      pathname: string | null;
-      query: Record<string, any>;
-    }>({ pathname: null, query: {} });
+  const [contextProps] = useNavigationContainerContext();
+  const [state, setState] = React.useState<{
+    pathname: string | null;
+    query: Record<string, any>;
+  }>({ pathname: null, query: {} });
 
-    const onStateChange = useCallback(
-      (state) => {
-        if (state) {
-          const currentRoute = findFocusedRoute(state);
-          setState({
-            pathname: trimQuery(currentRoute?.path ?? "/"),
-            query: currentRoute?.params ?? {},
-          });
-        }
-      },
-      [setState]
-    );
+  const onStateChange = useCallback(
+    (state) => {
+      if (state) {
+        const currentRoute = findFocusedRoute(state);
+        setState({
+          pathname: trimQuery(currentRoute?.path ?? "/"),
+          query: currentRoute?.params ?? {},
+        });
+      }
+    },
+    [setState]
+  );
 
-    return (
-      <VirtualRouteContext.Provider value={state}>
-        {/* @ts-expect-error: children are required */}
-        <NavigationContainer
-          {...props}
-          {...contextProps}
-          ref={navigationRef}
-          onReady={() => {
-            contextProps.onReady?.();
-            SplashModule?.hideAsync();
-            const initialState = navigationRef.current?.getRootState();
-            onStateChange(initialState);
-          }}
-          onStateChange={(state) => {
-            contextProps.onStateChange?.(state);
-            onStateChange(state);
-          }}
-        />
-      </VirtualRouteContext.Provider>
-    );
-  }
-);
+  return (
+    <VirtualRouteContext.Provider value={state}>
+      {/* @ts-expect-error: children are required */}
+      <NavigationContainer
+        {...props}
+        {...contextProps}
+        ref={navigationRef}
+        onReady={() => {
+          contextProps.onReady?.();
+          SplashModule?.hideAsync();
+          const initialState = navigationRef.current?.getRootState();
+          onStateChange(initialState);
+        }}
+        onStateChange={(state) => {
+          contextProps.onStateChange?.(state);
+          onStateChange(state);
+        }}
+      />
+    </VirtualRouteContext.Provider>
+  );
+}
 
 export function RootContainer({
   documentTitle,
@@ -148,4 +147,4 @@ export function RootContainer({
 /** Get the root navigation container ref. */
 RootContainer.getRef = () => {
   return navigationRef;
-}
+};


### PR DESCRIPTION
Related to https://github.com/expo/router/issues/14#issuecomment-1262415791

Expose the root navigation container ref for detecting if the layout has loaded or not.