### PR TITLE
fix: update router path methods to support initial navigation to nested route

### DIFF
--- a/packages/expo-router/src/fork/__tests__/getPathFromState-upstream.test.node.ts
+++ b/packages/expo-router/src/fork/__tests__/getPathFromState-upstream.test.node.ts
@@ -1585,7 +1585,7 @@ it("matches wildcard patterns at nested level", () => {
       getStateFromPath<object>(path, config) as State,
       config
     )
-  ).toBe("/bar/42/bar/42/whatever/baz/initt");
+  ).toBe(path);
 });
 
 it("matches wildcard patterns at nested level with exact", () => {

--- a/packages/expo-router/src/fork/__tests__/getPathFromState-upstream.test.node.ts
+++ b/packages/expo-router/src/fork/__tests__/getPathFromState-upstream.test.node.ts
@@ -1,0 +1,1723 @@
+// Ensure all the upstream tests from @react-navigation/core pass.
+
+import type { NavigationState, PartialState } from "@react-navigation/routers";
+
+import getPathFromState from "../getPathFromState";
+import getStateFromPath from "../getStateFromPath";
+
+type State = PartialState<NavigationState>;
+
+it("converts state to path string", () => {
+  const state = {
+    routes: [
+      {
+        name: "foo",
+        state: {
+          index: 1,
+          routes: [
+            { name: "boo" },
+            {
+              name: "bar",
+              params: { fruit: "apple" },
+              state: {
+                routes: [
+                  {
+                    name: "baz qux",
+                    params: { author: "jane", valid: true },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      },
+    ],
+  };
+
+  const path = "/foo/bar/baz%20qux?author=jane&valid=true";
+
+  expect(getPathFromState<object>(state)).toBe(path);
+  expect(
+    getPathFromState<object>(getStateFromPath<object>(path) as State)
+  ).toBe(path);
+});
+
+it("converts state to path string with config", () => {
+  const path = "/few/bar/sweet/apple/baz/jane?id=x10&valid=true";
+  const config = {
+    screens: {
+      Foo: {
+        path: "few",
+        screens: {
+          Bar: {
+            path: "bar/:type/:fruit",
+            screens: {
+              Baz: {
+                path: "baz/:author",
+                parse: {
+                  author: (author: string) =>
+                    author.replace(/^\w/, (c) => c.toUpperCase()),
+                  id: (id: string) => Number(id.replace(/^x/, "")),
+                  valid: Boolean,
+                },
+                stringify: {
+                  author: (author: string) => author.toLowerCase(),
+                  id: (id: number) => `x${id}`,
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  };
+
+  const state = {
+    routes: [
+      {
+        name: "Foo",
+        state: {
+          index: 1,
+          routes: [
+            { name: "boo" },
+            {
+              name: "Bar",
+              params: { fruit: "apple", type: "sweet", avaliable: false },
+              state: {
+                routes: [
+                  {
+                    name: "Baz",
+                    params: {
+                      author: "Jane",
+                      id: 10,
+                      valid: true,
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      },
+    ],
+  };
+
+  expect(getPathFromState<object>(state, config)).toBe(path);
+  expect(
+    getPathFromState<object>(
+      getStateFromPath<object>(path, config) as State,
+      config
+    )
+  ).toBe(path);
+});
+
+it("handles route without param", () => {
+  const path = "/foo/bar";
+  const state = {
+    routes: [
+      {
+        name: "foo",
+        state: {
+          routes: [{ name: "bar" }],
+        },
+      },
+    ],
+  };
+
+  expect(getPathFromState<object>(state)).toBe(path);
+  expect(
+    getPathFromState<object>(getStateFromPath<object>(path) as State)
+  ).toBe(path);
+});
+
+it("doesn't add query param for empty params", () => {
+  const path = "/foo";
+  const state = {
+    routes: [
+      {
+        name: "foo",
+        params: {},
+      },
+    ],
+  };
+
+  expect(getPathFromState<object>(state)).toBe(path);
+  expect(
+    getPathFromState<object>(getStateFromPath<object>(path) as State)
+  ).toBe(path);
+});
+
+it("handles state with config with nested screens", () => {
+  const path =
+    "/foo/foe/bar/sweet/apple/baz/jane?answer=42&count=10&valid=true";
+  const config = {
+    screens: {
+      Foo: {
+        path: "foo",
+        screens: {
+          Foe: {
+            path: "foe",
+            screens: {
+              Bar: {
+                path: "bar/:type/:fruit",
+                screens: {
+                  Baz: {
+                    path: "baz/:author",
+                    parse: {
+                      author: (author: string) =>
+                        author.replace(/^\w/, (c) => c.toUpperCase()),
+                      count: Number,
+                      valid: Boolean,
+                    },
+                    stringify: {
+                      author: (author: string) => author.toLowerCase(),
+                      id: (id: number) => `x${id}`,
+                      unknown: (_: unknown) => "x",
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  };
+
+  const state = {
+    routes: [
+      {
+        name: "Foo",
+        state: {
+          routes: [
+            {
+              name: "Foe",
+              state: {
+                routes: [
+                  {
+                    name: "Bar",
+                    params: { fruit: "apple", type: "sweet" },
+                    state: {
+                      routes: [
+                        {
+                          name: "Baz",
+                          params: {
+                            answer: "42",
+                            author: "Jane",
+                            count: "10",
+                            valid: true,
+                          },
+                        },
+                      ],
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      },
+    ],
+  };
+
+  expect(getPathFromState<object>(state, config)).toBe(path);
+  expect(
+    getPathFromState<object>(
+      getStateFromPath<object>(path, config) as State,
+      config
+    )
+  ).toBe(path);
+});
+
+it("handles state with config with nested screens and exact", () => {
+  const path = "/foe/bar/sweet/apple/baz/jane?answer=42&count=10&valid=true";
+  const config = {
+    screens: {
+      Foo: {
+        path: "foo",
+        screens: {
+          Foe: {
+            path: "foe",
+            exact: true,
+            screens: {
+              Bar: {
+                path: "bar/:type/:fruit",
+                screens: {
+                  Baz: {
+                    path: "baz/:author",
+                    parse: {
+                      author: (author: string) =>
+                        author.replace(/^\w/, (c) => c.toUpperCase()),
+                      count: Number,
+                      valid: Boolean,
+                    },
+                    stringify: {
+                      author: (author: string) => author.toLowerCase(),
+                      id: (id: number) => `x${id}`,
+                      unknown: (_: unknown) => "x",
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  };
+
+  const state = {
+    routes: [
+      {
+        name: "Foo",
+        state: {
+          routes: [
+            {
+              name: "Foe",
+              state: {
+                routes: [
+                  {
+                    name: "Bar",
+                    params: { fruit: "apple", type: "sweet" },
+                    state: {
+                      routes: [
+                        {
+                          name: "Baz",
+                          params: {
+                            answer: "42",
+                            author: "Jane",
+                            count: "10",
+                            valid: true,
+                          },
+                        },
+                      ],
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      },
+    ],
+  };
+
+  expect(getPathFromState<object>(state, config)).toBe(path);
+  expect(
+    getPathFromState<object>(
+      getStateFromPath<object>(path, config) as State,
+      config
+    )
+  ).toBe(path);
+});
+
+it("handles state with config with nested screens and unused configs", () => {
+  const path = "/foo/foe/baz/jane?answer=42&count=10&valid=true";
+  const config = {
+    screens: {
+      Foo: {
+        path: "foo",
+        screens: {
+          Foe: {
+            path: "foe",
+            screens: {
+              Baz: {
+                path: "baz/:author",
+                parse: {
+                  author: (author: string) =>
+                    author.replace(/^\w/, (c) => c.toUpperCase()),
+                  count: Number,
+                  valid: Boolean,
+                },
+                stringify: {
+                  author: (author: string) =>
+                    author.replace(/^\w/, (c) => c.toLowerCase()),
+                  unknown: (_: unknown) => "x",
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  };
+
+  const state = {
+    routes: [
+      {
+        name: "Foo",
+        state: {
+          routes: [
+            {
+              name: "Foe",
+              state: {
+                routes: [
+                  {
+                    name: "Baz",
+                    params: {
+                      answer: "42",
+                      author: "Jane",
+                      count: 10,
+                      valid: true,
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      },
+    ],
+  };
+
+  expect(getPathFromState<object>(state, config)).toBe(path);
+  expect(
+    getPathFromState<object>(
+      getStateFromPath<object>(path, config) as State,
+      config
+    )
+  ).toBe(path);
+});
+
+it("handles state with config with nested screens and unused configs with exact", () => {
+  const path = "/foe/baz/jane?answer=42&count=10&valid=true";
+  const config = {
+    screens: {
+      Foo: {
+        path: "foo",
+        screens: {
+          Foe: {
+            path: "foe",
+            exact: true,
+            screens: {
+              Baz: {
+                path: "baz/:author",
+                parse: {
+                  author: (author: string) =>
+                    author.replace(/^\w/, (c) => c.toUpperCase()),
+                  count: Number,
+                  valid: Boolean,
+                },
+                stringify: {
+                  author: (author: string) =>
+                    author.replace(/^\w/, (c) => c.toLowerCase()),
+                  unknown: (_: unknown) => "x",
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  };
+
+  const state = {
+    routes: [
+      {
+        name: "Foo",
+        state: {
+          routes: [
+            {
+              name: "Foe",
+              state: {
+                routes: [
+                  {
+                    name: "Baz",
+                    params: {
+                      answer: "42",
+                      author: "Jane",
+                      count: 10,
+                      valid: true,
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      },
+    ],
+  };
+
+  expect(getPathFromState<object>(state, config)).toBe(path);
+  expect(
+    getPathFromState<object>(
+      getStateFromPath<object>(path, config) as State,
+      config
+    )
+  ).toBe(path);
+});
+
+it("handles nested object with stringify in it", () => {
+  const path = "/bar/sweet/apple/foo/bis/jane?answer=42&count=10&valid=true";
+  const config = {
+    screens: {
+      Bar: {
+        path: "bar/:type/:fruit",
+        screens: {
+          Foo: {
+            path: "foo",
+            screens: {
+              Foe: {
+                path: "foe",
+              },
+              Baz: {
+                screens: {
+                  Bos: "bos",
+                  Bis: {
+                    path: "bis/:author",
+                    stringify: {
+                      author: (author: string) =>
+                        author.replace(/^\w/, (c) => c.toLowerCase()),
+                    },
+                    parse: {
+                      author: (author: string) =>
+                        author.replace(/^\w/, (c) => c.toUpperCase()),
+                      count: Number,
+                      valid: Boolean,
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  };
+
+  const state = {
+    routes: [
+      {
+        name: "Bar",
+        params: { fruit: "apple", type: "sweet" },
+        state: {
+          routes: [
+            {
+              name: "Foo",
+              state: {
+                routes: [
+                  {
+                    name: "Baz",
+                    state: {
+                      routes: [
+                        {
+                          name: "Bis",
+                          params: {
+                            answer: "42",
+                            author: "Jane",
+                            count: 10,
+                            valid: true,
+                          },
+                        },
+                      ],
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      },
+    ],
+  };
+
+  expect(getPathFromState<object>(state, config)).toBe(path);
+  expect(
+    getPathFromState<object>(
+      getStateFromPath<object>(path, config) as State,
+      config
+    )
+  ).toBe(path);
+});
+
+it("handles nested object with stringify in it with exact", () => {
+  const path = "/bis/jane?answer=42&count=10&valid=true";
+  const config = {
+    screens: {
+      Bar: {
+        path: "bar/:type/:fruit",
+        screens: {
+          Foo: {
+            path: "foo",
+            screens: {
+              Foe: {
+                path: "foe",
+              },
+              Baz: {
+                path: "baz",
+                screens: {
+                  Bos: "bos",
+                  Bis: {
+                    path: "bis/:author",
+                    exact: true,
+                    stringify: {
+                      author: (author: string) =>
+                        author.replace(/^\w/, (c) => c.toLowerCase()),
+                    },
+                    parse: {
+                      author: (author: string) =>
+                        author.replace(/^\w/, (c) => c.toUpperCase()),
+                      count: Number,
+                      valid: Boolean,
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  };
+
+  const state = {
+    routes: [
+      {
+        name: "Bar",
+        params: { fruit: "apple", type: "sweet" },
+        state: {
+          routes: [
+            {
+              name: "Foo",
+              state: {
+                routes: [
+                  {
+                    name: "Baz",
+                    state: {
+                      routes: [
+                        {
+                          name: "Bis",
+                          params: {
+                            answer: "42",
+                            author: "Jane",
+                            count: 10,
+                            valid: true,
+                          },
+                        },
+                      ],
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      },
+    ],
+  };
+
+  expect(getPathFromState<object>(state, config)).toBe(path);
+  expect(
+    getPathFromState<object>(
+      getStateFromPath<object>(path, config) as State,
+      config
+    )
+  ).toBe(path);
+});
+
+it("handles nested object for second route depth", () => {
+  const path = "/foo/bar/baz";
+  const config = {
+    screens: {
+      Foo: {
+        path: "foo",
+        screens: {
+          Foe: "foe",
+          Bar: {
+            path: "bar",
+            screens: {
+              Baz: "baz",
+            },
+          },
+        },
+      },
+    },
+  };
+
+  const state = {
+    routes: [
+      {
+        name: "Foo",
+        state: {
+          routes: [
+            {
+              name: "Bar",
+              state: {
+                routes: [{ name: "Baz" }],
+              },
+            },
+          ],
+        },
+      },
+    ],
+  };
+
+  expect(getPathFromState<object>(state, config)).toBe(path);
+  expect(
+    getPathFromState<object>(
+      getStateFromPath<object>(path, config) as State,
+      config
+    )
+  ).toBe(path);
+});
+
+it("handles nested object for second route depth with exact", () => {
+  const path = "/baz";
+  const config = {
+    screens: {
+      Foo: {
+        path: "foo",
+        screens: {
+          Foe: "foe",
+          Bar: {
+            path: "bar",
+            screens: {
+              Baz: {
+                path: "baz",
+                exact: true,
+              },
+            },
+          },
+        },
+      },
+    },
+  };
+
+  const state = {
+    routes: [
+      {
+        name: "Foo",
+        state: {
+          routes: [
+            {
+              name: "Bar",
+              state: {
+                routes: [{ name: "Baz" }],
+              },
+            },
+          ],
+        },
+      },
+    ],
+  };
+
+  expect(getPathFromState<object>(state, config)).toBe(path);
+  expect(
+    getPathFromState<object>(
+      getStateFromPath<object>(path, config) as State,
+      config
+    )
+  ).toBe(path);
+});
+
+it("handles nested object for second route depth and path and stringify in roots", () => {
+  const path = "/foo/dathomir/bar/42/baz";
+  const config = {
+    screens: {
+      Foo: {
+        path: "foo/:planet",
+        stringify: {
+          id: (id: number) => `planet=${id}`,
+        },
+        screens: {
+          Foe: "foe",
+          Bar: {
+            path: "bar/:id",
+            parse: {
+              id: Number,
+            },
+            screens: {
+              Baz: "baz",
+            },
+          },
+        },
+      },
+    },
+  };
+
+  const state = {
+    routes: [
+      {
+        name: "Foo",
+        params: { planet: "dathomir" },
+        state: {
+          routes: [
+            {
+              name: "Bar",
+              state: {
+                routes: [{ name: "Baz", params: { id: 42 } }],
+              },
+            },
+          ],
+        },
+      },
+    ],
+  };
+
+  expect(getPathFromState<object>(state, config)).toBe(path);
+  expect(
+    getPathFromState<object>(
+      getStateFromPath<object>(path, config) as State,
+      config
+    )
+  ).toBe(path);
+});
+
+it("handles nested object for second route depth and path and stringify in roots with exact", () => {
+  const path = "/baz";
+  const config = {
+    screens: {
+      Foo: {
+        path: "foo/:id",
+        stringify: {
+          id: (id: number) => `id=${id}`,
+        },
+        screens: {
+          Foe: "foe",
+          Bar: {
+            path: "bar/:id",
+            stringify: {
+              id: (id: number) => `id=${id}`,
+            },
+            parse: {
+              id: Number,
+            },
+            screens: {
+              Baz: {
+                path: "baz",
+                exact: true,
+              },
+            },
+          },
+        },
+      },
+    },
+  };
+
+  const state = {
+    routes: [
+      {
+        name: "Foo",
+        state: {
+          routes: [
+            {
+              name: "Bar",
+              state: {
+                routes: [{ name: "Baz" }],
+              },
+            },
+          ],
+        },
+      },
+    ],
+  };
+
+  expect(getPathFromState<object>(state, config)).toBe(path);
+  expect(
+    getPathFromState<object>(
+      getStateFromPath<object>(path, config) as State,
+      config
+    )
+  ).toBe(path);
+});
+
+it("ignores empty string paths", () => {
+  const path = "/bar";
+  const config = {
+    screens: {
+      Foo: {
+        path: "",
+        screens: {
+          Foe: "foe",
+        },
+      },
+      Bar: "bar",
+    },
+  };
+
+  const state = {
+    routes: [
+      {
+        name: "Foo",
+        state: {
+          routes: [{ name: "Bar" }],
+        },
+      },
+    ],
+  };
+
+  expect(getPathFromState<object>(state, config)).toBe(path);
+  expect(
+    getPathFromState<object>(
+      getStateFromPath<object>(path, config) as State,
+      config
+    )
+  ).toBe(path);
+});
+
+it("keeps query params if path is empty", () => {
+  const path = "/?foo=42";
+  const config = {
+    screens: {
+      Foo: {
+        screens: {
+          Foe: "foe",
+          Bar: {
+            screens: {
+              Qux: {
+                path: "",
+                parse: { foo: Number },
+              },
+              Baz: "baz",
+            },
+          },
+        },
+      },
+    },
+  };
+
+  const state = {
+    routes: [
+      {
+        name: "Foo",
+        state: {
+          routes: [
+            {
+              name: "Bar",
+              state: {
+                routes: [{ name: "Qux", params: { foo: 42 } }],
+              },
+            },
+          ],
+        },
+      },
+    ],
+  };
+
+  expect(getPathFromState<object>(state, config)).toBe(path);
+  expect(
+    getPathFromState<object>(
+      getStateFromPath<object>(path, config) as State,
+      config
+    )
+  ).toEqual(path);
+});
+
+it("does not use Object.prototype properties as parsing functions", () => {
+  const path = "/?toString=42";
+  const config = {
+    screens: {
+      Foo: {
+        screens: {
+          Foe: "foe",
+          Bar: {
+            screens: {
+              Qux: {
+                path: "",
+                parse: {},
+              },
+              Baz: "baz",
+            },
+          },
+        },
+      },
+    },
+  };
+
+  const state = {
+    routes: [
+      {
+        name: "Foo",
+        state: {
+          routes: [
+            {
+              name: "Bar",
+              state: {
+                routes: [{ name: "Qux", params: { toString: 42 } }],
+              },
+            },
+          ],
+        },
+      },
+    ],
+  };
+
+  expect(getPathFromState<object>(state, config)).toBe(path);
+  expect(
+    getPathFromState<object>(
+      getStateFromPath<object>(path, config) as State,
+      config
+    )
+  ).toEqual(path);
+});
+
+it("cuts nested configs too", () => {
+  const path = "/foo/baz";
+  const config = {
+    screens: {
+      Foo: {
+        path: "foo",
+        screens: {
+          Bar: {
+            path: "",
+            screens: {
+              Baz: {
+                path: "baz",
+              },
+            },
+          },
+        },
+      },
+    },
+  };
+
+  const state = {
+    routes: [
+      {
+        name: "Foo",
+        state: {
+          routes: [
+            {
+              name: "Bar",
+              state: {
+                routes: [{ name: "Baz" }],
+              },
+            },
+          ],
+        },
+      },
+    ],
+  };
+
+  expect(getPathFromState<object>(state, config)).toBe(path);
+  expect(
+    getPathFromState<object>(
+      getStateFromPath<object>(path, config) as State,
+      config
+    )
+  ).toBe(path);
+});
+
+it("cuts nested configs too with exact", () => {
+  const path = "/baz";
+  const config = {
+    screens: {
+      Foo: {
+        path: "foo",
+        screens: {
+          Bar: {
+            path: "",
+            exact: true,
+            screens: {
+              Baz: {
+                path: "baz",
+              },
+            },
+          },
+        },
+      },
+    },
+  };
+
+  const state = {
+    routes: [
+      {
+        name: "Foo",
+        state: {
+          routes: [
+            {
+              name: "Bar",
+              state: {
+                routes: [{ name: "Baz" }],
+              },
+            },
+          ],
+        },
+      },
+    ],
+  };
+
+  expect(getPathFromState<object>(state, config)).toBe(path);
+  expect(
+    getPathFromState<object>(
+      getStateFromPath<object>(path, config) as State,
+      config
+    )
+  ).toBe(path);
+});
+
+it("handles empty path at the end", () => {
+  const path = "/foo/bar";
+  const config = {
+    screens: {
+      Foo: {
+        path: "foo",
+        screens: {
+          Bar: "bar",
+        },
+      },
+      Baz: { path: "" },
+    },
+  };
+
+  const state = {
+    routes: [
+      {
+        name: "Foo",
+        state: {
+          routes: [
+            {
+              name: "Bar",
+              state: {
+                routes: [{ name: "Baz" }],
+              },
+            },
+          ],
+        },
+      },
+    ],
+  };
+
+  expect(getPathFromState<object>(state, config)).toBe(path);
+  expect(
+    getPathFromState<object>(
+      getStateFromPath<object>(path, config) as State,
+      config
+    )
+  ).toBe(path);
+});
+
+it('returns "/" for empty path', () => {
+  const path = "/";
+
+  const config = {
+    screens: {
+      Foo: {
+        path: "",
+        screens: {
+          Bar: "",
+        },
+      },
+    },
+  };
+
+  const state = {
+    routes: [
+      {
+        name: "Foo",
+        state: {
+          routes: [
+            {
+              name: "Bar",
+            },
+          ],
+        },
+      },
+    ],
+  };
+
+  expect(getPathFromState<object>(state, config)).toBe(path);
+  expect(
+    getPathFromState<object>(
+      getStateFromPath<object>(path, config) as State,
+      config
+    )
+  ).toBe(path);
+});
+
+it("parses no path specified", () => {
+  const path = "/bar";
+  const config = {
+    screens: {
+      Foo: {
+        screens: {
+          Foe: {},
+          Bar: "bar",
+        },
+      },
+    },
+  };
+
+  const state = {
+    routes: [
+      {
+        name: "Foo",
+        state: {
+          routes: [{ name: "Bar" }],
+        },
+      },
+    ],
+  };
+
+  expect(getPathFromState<object>(state, config)).toBe(path);
+  expect(
+    getPathFromState<object>(
+      getStateFromPath<object>(path, config) as State,
+      config
+    )
+  ).toBe(path);
+});
+
+it("strips undefined query params", () => {
+  const path = "/bar/sweet/apple/foo/bis/jane?count=10&valid=true";
+  const config = {
+    screens: {
+      Bar: {
+        path: "bar/:type/:fruit",
+        screens: {
+          Foo: {
+            path: "foo",
+            screens: {
+              Foe: {
+                path: "foe",
+              },
+              Baz: {
+                screens: {
+                  Bos: "bos",
+                  Bis: {
+                    path: "bis/:author",
+                    stringify: {
+                      author: (author: string) =>
+                        author.replace(/^\w/, (c) => c.toLowerCase()),
+                    },
+                    parse: {
+                      author: (author: string) =>
+                        author.replace(/^\w/, (c) => c.toUpperCase()),
+                      count: Number,
+                      valid: Boolean,
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  };
+
+  const state = {
+    routes: [
+      {
+        name: "Bar",
+        params: { fruit: "apple", type: "sweet" },
+        state: {
+          routes: [
+            {
+              name: "Foo",
+              state: {
+                routes: [
+                  {
+                    name: "Baz",
+                    state: {
+                      routes: [
+                        {
+                          name: "Bis",
+                          params: {
+                            author: "Jane",
+                            count: 10,
+                            valid: true,
+                          },
+                        },
+                      ],
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      },
+    ],
+  };
+
+  expect(getPathFromState<object>(state, config)).toBe(path);
+  expect(
+    getPathFromState<object>(
+      getStateFromPath<object>(path, config) as State,
+      config
+    )
+  ).toBe(path);
+});
+
+it("strips undefined query params with exact", () => {
+  const path = "/bis/jane?count=10&valid=true";
+  const config = {
+    screens: {
+      Bar: {
+        path: "bar/:type/:fruit",
+        screens: {
+          Foo: {
+            path: "foo",
+            screens: {
+              Foe: {
+                path: "foe",
+              },
+              Baz: {
+                screens: {
+                  Bos: "bos",
+                  Bis: {
+                    path: "bis/:author",
+                    exact: true,
+                    stringify: {
+                      author: (author: string) =>
+                        author.replace(/^\w/, (c) => c.toLowerCase()),
+                    },
+                    parse: {
+                      author: (author: string) =>
+                        author.replace(/^\w/, (c) => c.toUpperCase()),
+                      count: Number,
+                      valid: Boolean,
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  };
+
+  const state = {
+    routes: [
+      {
+        name: "Bar",
+        params: { fruit: "apple", type: "sweet" },
+        state: {
+          routes: [
+            {
+              name: "Foo",
+              state: {
+                routes: [
+                  {
+                    name: "Baz",
+                    state: {
+                      routes: [
+                        {
+                          name: "Bis",
+                          params: {
+                            author: "Jane",
+                            count: 10,
+                            valid: true,
+                          },
+                        },
+                      ],
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      },
+    ],
+  };
+
+  expect(getPathFromState<object>(state, config)).toBe(path);
+  expect(
+    getPathFromState<object>(
+      getStateFromPath<object>(path, config) as State,
+      config
+    )
+  ).toBe(path);
+});
+
+it("handles stripping all query params", () => {
+  const path = "/bar/sweet/apple/foo/bis/jane";
+  const config = {
+    screens: {
+      Bar: {
+        path: "bar/:type/:fruit",
+        screens: {
+          Foo: {
+            path: "foo",
+            screens: {
+              Foe: {
+                path: "foe",
+              },
+              Baz: {
+                screens: {
+                  Bos: "bos",
+                  Bis: {
+                    path: "bis/:author",
+                    stringify: {
+                      author: (author: string) =>
+                        author.replace(/^\w/, (c) => c.toLowerCase()),
+                    },
+                    parse: {
+                      author: (author: string) =>
+                        author.replace(/^\w/, (c) => c.toUpperCase()),
+                      count: Number,
+                      valid: Boolean,
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  };
+
+  const state = {
+    routes: [
+      {
+        name: "Bar",
+        params: { fruit: "apple", type: "sweet" },
+        state: {
+          routes: [
+            {
+              name: "Foo",
+              state: {
+                routes: [
+                  {
+                    name: "Baz",
+                    state: {
+                      routes: [
+                        {
+                          name: "Bis",
+                          params: {
+                            author: "Jane",
+                          },
+                        },
+                      ],
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      },
+    ],
+  };
+
+  expect(getPathFromState<object>(state, config)).toBe(path);
+  expect(
+    getPathFromState<object>(
+      getStateFromPath<object>(path, config) as State,
+      config
+    )
+  ).toBe(path);
+});
+
+it("handles stripping all query params with exact", () => {
+  const path = "/bis/jane";
+  const config = {
+    screens: {
+      Bar: {
+        path: "bar/:type/:fruit",
+        screens: {
+          Foo: {
+            path: "foo",
+            screens: {
+              Foe: {
+                path: "foe",
+              },
+              Baz: {
+                path: "baz",
+                screens: {
+                  Bos: "bos",
+                  Bis: {
+                    path: "bis/:author",
+                    exact: true,
+                    stringify: {
+                      author: (author: string) =>
+                        author.replace(/^\w/, (c) => c.toLowerCase()),
+                    },
+                    parse: {
+                      author: (author: string) =>
+                        author.replace(/^\w/, (c) => c.toUpperCase()),
+                      count: Number,
+                      valid: Boolean,
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  };
+
+  const state = {
+    routes: [
+      {
+        name: "Bar",
+        params: { fruit: "apple", type: "sweet" },
+        state: {
+          routes: [
+            {
+              name: "Foo",
+              state: {
+                routes: [
+                  {
+                    name: "Baz",
+                    state: {
+                      routes: [
+                        {
+                          name: "Bis",
+                          params: {
+                            author: "Jane",
+                          },
+                        },
+                      ],
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      },
+    ],
+  };
+
+  expect(getPathFromState<object>(state, config)).toBe(path);
+  expect(
+    getPathFromState<object>(
+      getStateFromPath<object>(path, config) as State,
+      config
+    )
+  ).toBe(path);
+});
+
+it("replaces undefined query params", () => {
+  const path = "/bar/undefined/apple";
+  const config = {
+    screens: {
+      Bar: "bar/:type/:fruit",
+    },
+  };
+
+  const state = {
+    routes: [
+      {
+        name: "Bar",
+        params: { fruit: "apple" },
+      },
+    ],
+  };
+
+  // TODO(EvanBacon): Investigate why getStateFromPath isn't matching
+  expect(getPathFromState<object>(state, config)).toBe("/bar/apple");
+  expect(
+    getPathFromState<object>(
+      getStateFromPath<object>(path, config) as State,
+      config
+    )
+  ).toBe(path);
+});
+
+it("matches wildcard patterns at root", () => {
+  const path = "/test/bar/42/whatever";
+  const config = {
+    screens: {
+      404: "*",
+      Foo: {
+        screens: {
+          Bar: {
+            path: "/bar/:id/",
+          },
+        },
+      },
+    },
+  };
+
+  const state = {
+    routes: [{ name: "404" }],
+  };
+
+  // NOTE(EvanBacon): This is custom behavior for our router
+  expect(getPathFromState<object>(state, config)).toBe("/");
+  expect(
+    getPathFromState<object>(
+      getStateFromPath<object>(path, config) as State,
+      config
+    )
+  ).toBe("/test/bar/42/whatever");
+});
+
+it("matches wildcard patterns at nested level", () => {
+  const path = "/bar/42/whatever/baz/initt";
+  const config = {
+    screens: {
+      Foo: {
+        screens: {
+          Bar: {
+            path: "/bar/:id/",
+            screens: {
+              404: "*",
+            },
+          },
+        },
+      },
+    },
+  };
+
+  const state = {
+    routes: [
+      {
+        name: "Foo",
+        state: {
+          routes: [
+            {
+              name: "Bar",
+              params: { id: "42" },
+              state: {
+                routes: [{ name: "404" }],
+              },
+            },
+          ],
+        },
+      },
+    ],
+  };
+
+  // NOTE(EvanBacon): This is custom behavior for our router
+  expect(getPathFromState<object>(state, config)).toBe("/bar/42");
+  expect(
+    getPathFromState<object>(
+      getStateFromPath<object>(path, config) as State,
+      config
+    )
+  ).toBe("/bar/42/bar/42/whatever/baz/initt");
+});
+
+it("matches wildcard patterns at nested level with exact", () => {
+  const path = "/whatever";
+  const config = {
+    screens: {
+      Foo: {
+        screens: {
+          Bar: {
+            path: "/bar/:id/",
+            screens: {
+              404: {
+                path: "*",
+                exact: true,
+              },
+            },
+          },
+          Baz: {},
+        },
+      },
+    },
+  };
+
+  const state = {
+    routes: [
+      {
+        name: "Foo",
+        state: {
+          routes: [
+            {
+              name: "Bar",
+              state: {
+                routes: [{ name: "404" }],
+              },
+            },
+          ],
+        },
+      },
+    ],
+  };
+
+  // NOTE(EvanBacon): This is custom behavior for our router
+  expect(getPathFromState<object>(state, config)).toBe("/");
+  expect(
+    getPathFromState<object>(
+      getStateFromPath<object>(path, config) as State,
+      config
+    )
+  ).toBe(path);
+});
+
+it("tries to match wildcard patterns at the end", () => {
+  const path = "/bar/42/test";
+  const config = {
+    screens: {
+      Foo: {
+        screens: {
+          Bar: {
+            path: "/bar/:id/",
+            screens: {
+              404: "*",
+              Test: "test",
+            },
+          },
+        },
+      },
+    },
+  };
+
+  const state = {
+    routes: [
+      {
+        name: "Foo",
+        state: {
+          routes: [
+            {
+              name: "Bar",
+              params: { id: "42" },
+              state: {
+                routes: [{ name: "Test" }],
+              },
+            },
+          ],
+        },
+      },
+    ],
+  };
+
+  expect(getPathFromState<object>(state, config)).toBe(path);
+  expect(
+    getPathFromState<object>(
+      getStateFromPath<object>(path, config) as State,
+      config
+    )
+  ).toBe(path);
+});
+
+it("uses nearest parent wildcard match for unmatched paths", () => {
+  const path = "/bar/42/baz/test";
+  const config = {
+    screens: {
+      Foo: {
+        screens: {
+          Bar: {
+            path: "/bar/:id/",
+            screens: {
+              Baz: "baz",
+            },
+          },
+          404: "*",
+        },
+      },
+    },
+  };
+
+  const state = {
+    routes: [
+      {
+        name: "Foo",
+        state: {
+          routes: [{ name: "404" }],
+        },
+      },
+    ],
+  };
+
+  // NOTE(EvanBacon): This is custom behavior for our router
+  expect(getPathFromState<object>(state, config)).toBe("/");
+  expect(
+    getPathFromState<object>(
+      getStateFromPath<object>(path, config) as State,
+      config
+    )
+  ).toBe("/bar/42/baz/test");
+});

--- a/packages/expo-router/src/fork/__tests__/getPathFromState.test.node.ts
+++ b/packages/expo-router/src/fork/__tests__/getPathFromState.test.node.ts
@@ -1,0 +1,66 @@
+import getPathFromState from "../getPathFromState";
+
+describe(getPathFromState, () => {
+  it(`should parse initial nested screen that doesn't have a state object`, () => {
+    // Happens when moving to a path in a nested stack navigator for the first time.
+    expect(
+      getPathFromState({
+        stale: false,
+        type: "stack",
+        key: "stack-SJm8YPL1n7zMtnG4BzUL4",
+        index: 0,
+        routeNames: ["index", "me", "search", "new-story"],
+        routes: [
+          {
+            name: "me",
+            params: {
+              initial: true,
+              screen: "lists",
+              params: {},
+              path: "/me/lists",
+            },
+            key: "me-NpM3lwFg-itsR-Jx2JSQD",
+          },
+        ],
+      })
+    ).toEqual("/me/lists");
+
+    // This is the subsequent state object after the initial state object.
+    expect(
+      getPathFromState({
+        stale: false,
+        type: "stack",
+        key: "stack-SJm8YPL1n7zMtnG4BzUL4",
+        index: 0,
+        routeNames: ["index", "me", "search", "new-story"],
+        routes: [
+          {
+            name: "me",
+            params: {
+              initial: true,
+              screen: "lists",
+              params: {},
+              path: "/me/lists",
+            },
+            state: {
+              stale: false,
+              type: "stack",
+              key: "stack-TkmK3B221tH45uOx5PyDh",
+              index: 0,
+              routeNames: ["index", "lists", "stories", "notifications"],
+              routes: [
+                {
+                  key: "lists-WCKjVlbNWi9e9NSfQj-N7",
+                  name: "lists",
+                  params: {},
+                  path: "/me/lists",
+                },
+              ],
+            },
+            key: "me-NpM3lwFg-itsR-Jx2JSQD",
+          },
+        ],
+      })
+    ).toEqual("/me/lists");
+  });
+});

--- a/packages/expo-router/src/fork/__tests__/getStateFromPath-upstream.test.node.ts
+++ b/packages/expo-router/src/fork/__tests__/getStateFromPath-upstream.test.node.ts
@@ -1,6 +1,7 @@
+import { findFocusedRoute } from "@react-navigation/native";
 import type { InitialState } from "@react-navigation/routers";
 import produce from "immer";
-import { findFocusedRoute } from "@react-navigation/native";
+
 import getPathFromState from "../getPathFromState";
 import getStateFromPath from "../getStateFromPath";
 

--- a/packages/expo-router/src/fork/__tests__/getStateFromPath-upstream.test.node.ts
+++ b/packages/expo-router/src/fork/__tests__/getStateFromPath-upstream.test.node.ts
@@ -1,0 +1,2678 @@
+import type { InitialState } from "@react-navigation/routers";
+import produce from "immer";
+import { findFocusedRoute } from "@react-navigation/native";
+import getPathFromState from "../getPathFromState";
+import getStateFromPath from "../getStateFromPath";
+
+const changePath = <T extends InitialState>(state: T, path: string): T =>
+  produce(state, (draftState) => {
+    const route = findFocusedRoute(draftState);
+    // @ts-expect-error: immer won't mutate this
+    route.path = path;
+  });
+
+it("returns undefined for invalid path", () => {
+  expect(getStateFromPath<object>("//")).toBe(undefined);
+});
+
+it("converts path string to initial state", () => {
+  const path = "foo/bar/baz%20qux?author=jane%20%26%20co&valid=true";
+  const state = {
+    routes: [
+      {
+        name: "foo",
+        state: {
+          routes: [
+            {
+              name: "bar",
+              state: {
+                routes: [
+                  {
+                    name: "baz qux",
+                    params: { author: "jane & co", valid: "true" },
+                    path,
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      },
+    ],
+  };
+
+  expect(getStateFromPath<object>(path)).toEqual(state);
+  expect(getStateFromPath<object>(getPathFromState<object>(state))).toEqual(
+    changePath(state, "/foo/bar/baz%20qux?author=jane%20%26%20co&valid=true")
+  );
+});
+
+it("converts path string to initial state with config", () => {
+  const path = "/foo/bar/sweet/apple/baz/jane?count=10&answer=42&valid=true";
+  const config = {
+    screens: {
+      Foo: {
+        path: "foo",
+        screens: {
+          Bar: {
+            path: "bar/:type/:fruit",
+            screens: {
+              Baz: {
+                path: "baz/:author",
+                parse: {
+                  author: (author: string) =>
+                    author.replace(/^\w/, (c) => c.toUpperCase()),
+                  count: Number,
+                  valid: Boolean,
+                },
+                stringify: {
+                  author: (author: string) => author.toLowerCase(),
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  };
+
+  const state = {
+    routes: [
+      {
+        name: "Foo",
+        params: {
+          author: "Jane",
+          fruit: "apple",
+          type: "sweet",
+        },
+        state: {
+          routes: [
+            {
+              name: "Bar",
+              params: { author: "Jane", fruit: "apple", type: "sweet" },
+              state: {
+                routes: [
+                  {
+                    name: "Baz",
+                    params: {
+                      author: "Jane",
+                      count: 10,
+                      fruit: "apple",
+                      type: "sweet",
+                      answer: "42",
+                      valid: true,
+                    },
+                    path,
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      },
+    ],
+  };
+
+  expect(getStateFromPath<object>(path, config)).toEqual(state);
+  expect(
+    getStateFromPath<object>(getPathFromState<object>(state, config), config)
+  ).toEqual(state);
+});
+
+it("handles leading slash when converting", () => {
+  const path = "/foo/bar/?count=42";
+
+  expect(getStateFromPath<object>(path)).toEqual({
+    routes: [
+      {
+        name: "foo",
+        state: {
+          routes: [
+            {
+              name: "bar",
+              params: { count: "42" },
+              path,
+            },
+          ],
+        },
+      },
+    ],
+  });
+});
+
+it("handles ending slash when converting", () => {
+  const path = "foo/bar/?count=42";
+
+  expect(getStateFromPath<object>(path)).toEqual({
+    routes: [
+      {
+        name: "foo",
+        state: {
+          routes: [
+            {
+              name: "bar",
+              params: { count: "42" },
+              path,
+            },
+          ],
+        },
+      },
+    ],
+  });
+});
+
+it("handles route without param", () => {
+  const path = "foo/bar";
+  const state = {
+    routes: [
+      {
+        name: "foo",
+        state: {
+          routes: [{ name: "bar", path }],
+        },
+      },
+    ],
+  };
+
+  expect(getStateFromPath<object>(path)).toEqual(state);
+  expect(getStateFromPath<object>(getPathFromState<object>(state))).toEqual(
+    changePath(state, "/foo/bar")
+  );
+});
+
+it("converts path string to initial state with config with nested screens", () => {
+  const path = "/foe/bar/sweet/apple/baz/jane?count=10&answer=42&valid=true";
+  const config = {
+    screens: {
+      Foo: {
+        path: "foo",
+        screens: {
+          Foe: {
+            path: "foe",
+            exact: true,
+            screens: {
+              Bar: {
+                path: "bar/:type/:fruit",
+                screens: {
+                  Baz: {
+                    path: "baz/:author",
+                    parse: {
+                      author: (author: string) =>
+                        author.replace(/^\w/, (c) => c.toUpperCase()),
+                      count: Number,
+                      valid: Boolean,
+                    },
+                    stringify: {
+                      author: (author: string) => author.toLowerCase(),
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  };
+
+  const state = {
+    routes: [
+      {
+        name: "Foo",
+        params: {
+          fruit: "apple",
+          type: "sweet",
+          author: "Jane",
+        },
+        state: {
+          routes: [
+            {
+              name: "Foe",
+              params: {
+                fruit: "apple",
+                type: "sweet",
+                author: "Jane",
+              },
+              state: {
+                routes: [
+                  {
+                    name: "Bar",
+                    params: {
+                      fruit: "apple",
+                      type: "sweet",
+                      author: "Jane",
+                    },
+                    state: {
+                      routes: [
+                        {
+                          name: "Baz",
+                          params: {
+                            fruit: "apple",
+                            type: "sweet",
+                            author: "Jane",
+                            count: 10,
+                            answer: "42",
+                            valid: true,
+                          },
+                          path,
+                        },
+                      ],
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      },
+    ],
+  };
+
+  expect(getStateFromPath<object>(path, config)).toEqual(state);
+  expect(
+    getStateFromPath<object>(getPathFromState<object>(state, config), config)
+  ).toEqual(state);
+});
+
+it("converts path string to initial state with config with nested screens and unused parse functions", () => {
+  const path = "/foe/baz/jane?count=10&answer=42&valid=true";
+  const config = {
+    screens: {
+      Foo: {
+        path: "foo",
+        screens: {
+          Foe: {
+            path: "foe",
+            exact: true,
+            screens: {
+              Baz: {
+                path: "baz/:author",
+                parse: {
+                  author: (author: string) =>
+                    author.replace(/^\w/, (c) => c.toUpperCase()),
+                  count: Number,
+                  valid: Boolean,
+                  id: Boolean,
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  };
+
+  const state = {
+    routes: [
+      {
+        name: "Foo",
+        params: {
+          author: "Jane",
+        },
+        state: {
+          routes: [
+            {
+              name: "Foe",
+              params: {
+                author: "Jane",
+              },
+              state: {
+                routes: [
+                  {
+                    name: "Baz",
+                    params: {
+                      author: "Jane",
+                      count: 10,
+                      answer: "42",
+                      valid: true,
+                    },
+                    path,
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      },
+    ],
+  };
+
+  expect(getStateFromPath<object>(path, config)).toEqual(state);
+  expect(
+    getStateFromPath<object>(getPathFromState<object>(state, config), config)
+  ).toEqual(changePath(state, "/foe/baz/Jane?count=10&answer=42&valid=true"));
+});
+
+it("handles nested object with unused configs and with parse in it", () => {
+  const path = "/bar/sweet/apple/foe/bis/jane?count=10&answer=42&valid=true";
+  const config = {
+    screens: {
+      Bar: {
+        path: "bar/:type/:fruit",
+        screens: {
+          Foo: {
+            screens: {
+              Foe: {
+                path: "foe",
+                screens: {
+                  Baz: {
+                    screens: {
+                      Bos: {
+                        path: "bos",
+                        exact: true,
+                      },
+                      Bis: {
+                        path: "bis/:author",
+                        stringify: {
+                          author: (author: string) =>
+                            author.replace(/^\w/, (c) => c.toLowerCase()),
+                        },
+                        parse: {
+                          author: (author: string) =>
+                            author.replace(/^\w/, (c) => c.toUpperCase()),
+                          count: Number,
+                          valid: Boolean,
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  };
+
+  const state = {
+    routes: [
+      {
+        name: "Bar",
+        params: { fruit: "apple", type: "sweet", author: "Jane" },
+        state: {
+          routes: [
+            {
+              name: "Foo",
+              params: {
+                author: "Jane",
+                fruit: "apple",
+                type: "sweet",
+              },
+              state: {
+                routes: [
+                  {
+                    name: "Foe",
+                    params: {
+                      author: "Jane",
+                      fruit: "apple",
+                      type: "sweet",
+                    },
+                    state: {
+                      routes: [
+                        {
+                          name: "Baz",
+                          params: {
+                            author: "Jane",
+                            fruit: "apple",
+                            type: "sweet",
+                          },
+                          state: {
+                            routes: [
+                              {
+                                name: "Bis",
+                                params: {
+                                  author: "Jane",
+                                  count: 10,
+                                  answer: "42",
+                                  valid: true,
+                                  fruit: "apple",
+                                  type: "sweet",
+                                },
+                                path,
+                              },
+                            ],
+                          },
+                        },
+                      ],
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      },
+    ],
+  };
+
+  expect(getStateFromPath<object>(path, config)).toEqual(state);
+  expect(
+    getStateFromPath<object>(getPathFromState<object>(state, config), config)
+  ).toEqual(state);
+});
+
+it("handles parse in nested object for second route depth", () => {
+  const path = "/baz";
+  const config = {
+    screens: {
+      Foo: {
+        path: "foo",
+        screens: {
+          Foe: {
+            path: "foe",
+            exact: true,
+          },
+          Bar: {
+            path: "bar",
+            exact: true,
+            screens: {
+              Baz: {
+                path: "baz",
+                exact: true,
+              },
+            },
+          },
+        },
+      },
+    },
+  };
+
+  const state = {
+    routes: [
+      {
+        name: "Foo",
+        state: {
+          routes: [
+            {
+              name: "Bar",
+              state: {
+                routes: [{ name: "Baz", path }],
+              },
+            },
+          ],
+        },
+      },
+    ],
+  };
+
+  expect(getStateFromPath<object>(path, config)).toEqual(state);
+  expect(
+    getStateFromPath<object>(getPathFromState<object>(state, config), config)
+  ).toEqual(state);
+});
+
+it("handles parse in nested object for second route depth and and path and parse in roots", () => {
+  const path = "/baz";
+  const config = {
+    screens: {
+      Foo: {
+        path: "foo/:id",
+        parse: {
+          id: Number,
+        },
+        stringify: {
+          id: (id: number) => `id=${id}`,
+        },
+        screens: {
+          Foe: "foe",
+          Bar: {
+            screens: {
+              Baz: {
+                path: "baz",
+                exact: true,
+              },
+            },
+          },
+        },
+      },
+    },
+  };
+
+  const state = {
+    routes: [
+      {
+        name: "Foo",
+        state: {
+          routes: [
+            {
+              name: "Bar",
+              state: {
+                routes: [{ name: "Baz", path }],
+              },
+            },
+          ],
+        },
+      },
+    ],
+  };
+
+  expect(getStateFromPath<object>(path, config)).toEqual(state);
+  expect(
+    getStateFromPath<object>(getPathFromState<object>(state, config), config)
+  ).toEqual(state);
+});
+
+it("handles initialRouteName at top level", () => {
+  const path = "/baz";
+  const config = {
+    initialRouteName: "Boo",
+    screens: {
+      Foo: {
+        screens: {
+          Foe: "foe",
+          Bar: {
+            screens: {
+              Baz: "baz",
+            },
+          },
+        },
+      },
+    },
+  };
+
+  const state = {
+    index: 1,
+    routes: [
+      { name: "Boo" },
+      {
+        name: "Foo",
+        state: {
+          routes: [
+            {
+              name: "Bar",
+              state: {
+                routes: [{ name: "Baz", path }],
+              },
+            },
+          ],
+        },
+      },
+    ],
+  };
+
+  expect(getStateFromPath<object>(path, config)).toEqual(state);
+  expect(
+    getStateFromPath<object>(getPathFromState<object>(state, config), config)
+  ).toEqual(state);
+});
+
+it("handles initialRouteName inside a screen", () => {
+  const path = "/baz";
+  const config = {
+    screens: {
+      Foo: {
+        initialRouteName: "Foe",
+        screens: {
+          Foe: "foe",
+          Bar: {
+            screens: {
+              Baz: "baz",
+            },
+          },
+        },
+      },
+    },
+  };
+
+  const state = {
+    routes: [
+      {
+        name: "Foo",
+        state: {
+          index: 1,
+          routes: [
+            {
+              name: "Foe",
+            },
+            {
+              name: "Bar",
+              state: {
+                routes: [{ name: "Baz", path }],
+              },
+            },
+          ],
+        },
+      },
+    ],
+  };
+
+  expect(getStateFromPath<object>(path, config)).toEqual(state);
+  expect(
+    getStateFromPath<object>(getPathFromState<object>(state, config), config)
+  ).toEqual(state);
+});
+
+it("handles initialRouteName included in path", () => {
+  const path = "/baz";
+  const config = {
+    screens: {
+      Foo: {
+        initialRouteName: "Foe",
+        screens: {
+          Foe: {
+            screens: {
+              Baz: "baz",
+            },
+          },
+          Bar: "bar",
+        },
+      },
+    },
+  };
+
+  const state = {
+    routes: [
+      {
+        name: "Foo",
+        state: {
+          routes: [
+            {
+              name: "Foe",
+              state: {
+                routes: [{ name: "Baz", path }],
+              },
+            },
+          ],
+        },
+      },
+    ],
+  };
+
+  expect(getStateFromPath<object>(path, config)).toEqual(state);
+  expect(
+    getStateFromPath<object>(getPathFromState<object>(state, config), config)
+  ).toEqual(state);
+});
+
+it("handles two initialRouteNames", () => {
+  const path = "/bar/sweet/apple/foe/bis/jane?answer=42&count=10&valid=true";
+  const config = {
+    screens: {
+      Bar: {
+        path: "bar/:type/:fruit",
+        screens: {
+          Foo: {
+            screens: {
+              Foe: {
+                path: "foe",
+                screens: {
+                  Baz: {
+                    initialRouteName: "Bos",
+                    screens: {
+                      Bos: {
+                        path: "bos",
+                        exact: true,
+                      },
+                      Bis: {
+                        path: "bis/:author",
+                        stringify: {
+                          author: (author: string) =>
+                            author.replace(/^\w/, (c) => c.toLowerCase()),
+                        },
+                        parse: {
+                          author: (author: string) =>
+                            author.replace(/^\w/, (c) => c.toUpperCase()),
+                          count: Number,
+                          valid: Boolean,
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  };
+
+  const state = {
+    routes: [
+      {
+        name: "Bar",
+        params: { author: "Jane", fruit: "apple", type: "sweet" },
+        state: {
+          routes: [
+            {
+              name: "Foo",
+              params: { author: "Jane", fruit: "apple", type: "sweet" },
+              state: {
+                routes: [
+                  {
+                    name: "Foe",
+                    params: { author: "Jane", fruit: "apple", type: "sweet" },
+                    state: {
+                      routes: [
+                        {
+                          name: "Baz",
+                          params: {
+                            author: "Jane",
+                            fruit: "apple",
+                            type: "sweet",
+                          },
+                          state: {
+                            index: 1,
+                            routes: [
+                              { name: "Bos" },
+                              {
+                                name: "Bis",
+                                params: {
+                                  answer: "42",
+                                  author: "Jane",
+                                  count: 10,
+                                  valid: true,
+                                  fruit: "apple",
+                                  type: "sweet",
+                                },
+                                path,
+                              },
+                            ],
+                          },
+                        },
+                      ],
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      },
+    ],
+  };
+
+  expect(getStateFromPath<object>(path, config)).toEqual(state);
+  expect(
+    getStateFromPath<object>(getPathFromState<object>(state, config), config)
+  ).toEqual(state);
+});
+
+it("accepts initialRouteName without config for it", () => {
+  const path = "/bar/sweet/apple/foe/bis/jane?answer=42&count=10&valid=true";
+  const config = {
+    screens: {
+      Bar: {
+        path: "bar/:type/:fruit",
+        screens: {
+          Foo: {
+            screens: {
+              Foe: {
+                path: "foe",
+                screens: {
+                  Baz: {
+                    initialRouteName: "Bas",
+                    screens: {
+                      Bos: {
+                        path: "bos",
+                        exact: true,
+                      },
+                      Bis: {
+                        path: "bis/:author",
+                        stringify: {
+                          author: (author: string) =>
+                            author.replace(/^\w/, (c) => c.toLowerCase()),
+                        },
+                        parse: {
+                          author: (author: string) =>
+                            author.replace(/^\w/, (c) => c.toUpperCase()),
+                          count: Number,
+                          valid: Boolean,
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  };
+
+  const state = {
+    routes: [
+      {
+        name: "Bar",
+        params: { author: "Jane", fruit: "apple", type: "sweet" },
+        state: {
+          routes: [
+            {
+              name: "Foo",
+              params: { author: "Jane", fruit: "apple", type: "sweet" },
+              state: {
+                routes: [
+                  {
+                    name: "Foe",
+                    params: { author: "Jane", fruit: "apple", type: "sweet" },
+                    state: {
+                      routes: [
+                        {
+                          name: "Baz",
+                          params: {
+                            author: "Jane",
+                            fruit: "apple",
+                            type: "sweet",
+                          },
+                          state: {
+                            index: 1,
+                            routes: [
+                              {
+                                name: "Bas",
+                              },
+                              {
+                                name: "Bis",
+                                params: {
+                                  answer: "42",
+                                  author: "Jane",
+                                  count: 10,
+                                  fruit: "apple",
+                                  type: "sweet",
+                                  valid: true,
+                                },
+                                path: "/bar/sweet/apple/foe/bis/jane?answer=42&count=10&valid=true",
+                              },
+                            ],
+                          },
+                        },
+                      ],
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      },
+    ],
+  };
+
+  expect(getStateFromPath<object>(path, config)).toEqual(state);
+  expect(
+    getStateFromPath<object>(getPathFromState<object>(state, config), config)
+  ).toEqual(state);
+});
+
+it("returns undefined if path is empty and no matching screen is present", () => {
+  const config = {
+    screens: {
+      Foo: {
+        screens: {
+          Foe: "foe",
+          Bar: {
+            screens: {
+              Baz: "baz",
+            },
+          },
+        },
+      },
+    },
+  };
+
+  const path = "";
+
+  expect(getStateFromPath<object>(path, config)).toEqual(undefined);
+});
+
+it("returns matching screen if path is empty", () => {
+  const path = "";
+  const config = {
+    screens: {
+      Foo: {
+        screens: {
+          Foe: "foe",
+          Bar: {
+            screens: {
+              Qux: "",
+              Baz: "baz",
+            },
+          },
+        },
+      },
+    },
+  };
+
+  const state = {
+    routes: [
+      {
+        name: "Foo",
+        state: {
+          routes: [
+            {
+              name: "Bar",
+              state: {
+                routes: [{ name: "Qux", path }],
+              },
+            },
+          ],
+        },
+      },
+    ],
+  };
+
+  expect(getStateFromPath<object>(path, config)).toEqual(state);
+  expect(
+    getStateFromPath<object>(getPathFromState<object>(state, config), config)
+  ).toEqual(changePath(state, "/"));
+});
+
+it("returns matching screen if path is only slash", () => {
+  const path = "/";
+  const config = {
+    screens: {
+      Foo: {
+        screens: {
+          Foe: "foe",
+          Bar: {
+            screens: {
+              Qux: "",
+              Baz: "baz",
+            },
+          },
+        },
+      },
+    },
+  };
+
+  const state = {
+    routes: [
+      {
+        name: "Foo",
+        state: {
+          routes: [
+            {
+              name: "Bar",
+              state: {
+                routes: [{ name: "Qux", path }],
+              },
+            },
+          ],
+        },
+      },
+    ],
+  };
+
+  expect(getStateFromPath<object>(path, config)).toEqual(state);
+  expect(
+    getStateFromPath<object>(getPathFromState<object>(state, config), config)
+  ).toEqual(changePath(state, "/"));
+});
+
+it("returns matching screen with params if path is empty", () => {
+  const path = "?foo=42";
+  const config = {
+    screens: {
+      Foo: {
+        screens: {
+          Foe: "foe",
+          Bar: {
+            screens: {
+              Qux: {
+                path: "",
+                parse: { foo: Number },
+              },
+              Baz: "baz",
+            },
+          },
+        },
+      },
+    },
+  };
+
+  const state = {
+    routes: [
+      {
+        name: "Foo",
+        state: {
+          routes: [
+            {
+              name: "Bar",
+              state: {
+                routes: [{ name: "Qux", params: { foo: 42 }, path }],
+              },
+            },
+          ],
+        },
+      },
+    ],
+  };
+
+  expect(getStateFromPath<object>(path, config)).toEqual(state);
+  expect(
+    getStateFromPath<object>(getPathFromState<object>(state, config), config)
+  ).toEqual(changePath(state, "/?foo=42"));
+});
+
+it("doesn't match nested screen if path is empty", () => {
+  const config = {
+    screens: {
+      Foo: {
+        screens: {
+          Foe: "foe",
+          Bar: {
+            path: "bar",
+            screens: {
+              Qux: {
+                path: "",
+                parse: { foo: Number },
+              },
+            },
+          },
+        },
+      },
+    },
+  };
+
+  const path = "";
+
+  expect(getStateFromPath<object>(path, config)).toEqual(undefined);
+});
+
+it("chooses more exhaustive pattern", () => {
+  const path = "/foo/5";
+
+  const config = {
+    screens: {
+      Foe: {
+        path: "/",
+        initialRouteName: "Foo",
+        screens: {
+          Foo: "foo",
+          Bis: {
+            path: "foo/:id",
+            parse: {
+              id: Number,
+            },
+          },
+        },
+      },
+    },
+  };
+
+  const state = {
+    routes: [
+      {
+        name: "Foe",
+        params: {
+          id: 5,
+        },
+        state: {
+          index: 1,
+          routes: [
+            {
+              name: "Foo",
+            },
+            {
+              name: "Bis",
+              params: { id: 5 },
+              path,
+            },
+          ],
+        },
+      },
+    ],
+  };
+
+  expect(getStateFromPath<object>(path, config)).toEqual(state);
+  expect(
+    getStateFromPath<object>(getPathFromState<object>(state, config), config)
+  ).toEqual(state);
+});
+
+it("handles same paths beginnings", () => {
+  const path = "/foos";
+
+  const config = {
+    screens: {
+      Foe: {
+        path: "/",
+        initialRouteName: "Foo",
+        screens: {
+          Foo: "foo",
+          Bis: {
+            path: "foos",
+          },
+        },
+      },
+    },
+  };
+
+  const state = {
+    routes: [
+      {
+        name: "Foe",
+        state: {
+          index: 1,
+          routes: [
+            {
+              name: "Foo",
+            },
+            {
+              name: "Bis",
+              path,
+            },
+          ],
+        },
+      },
+    ],
+  };
+
+  expect(getStateFromPath<object>(path, config)).toEqual(state);
+  expect(
+    getStateFromPath<object>(getPathFromState<object>(state, config), config)
+  ).toEqual(state);
+});
+
+it("handles same paths beginnings with params", () => {
+  const path = "/foos/5";
+
+  const config = {
+    screens: {
+      Foe: {
+        path: "/",
+        initialRouteName: "Foo",
+        screens: {
+          Foo: "foo",
+          Bis: {
+            path: "foos/:id",
+            parse: {
+              id: Number,
+            },
+          },
+        },
+      },
+    },
+  };
+
+  const state = {
+    routes: [
+      {
+        name: "Foe",
+        params: {
+          id: 5,
+        },
+
+        state: {
+          index: 1,
+          routes: [
+            {
+              name: "Foo",
+            },
+            {
+              name: "Bis",
+              params: { id: 5 },
+              path,
+            },
+          ],
+        },
+      },
+    ],
+  };
+
+  expect(getStateFromPath<object>(path, config)).toEqual(state);
+  expect(
+    getStateFromPath<object>(getPathFromState<object>(state, config), config)
+  ).toEqual(state);
+});
+
+it("handles not taking path with too many segments", () => {
+  const path = "/foos/5";
+
+  const config = {
+    screens: {
+      Foe: {
+        path: "/",
+        initialRouteName: "Foo",
+        screens: {
+          Foo: "foo",
+          Bis: {
+            path: "foos/:id",
+            parse: {
+              id: Number,
+            },
+          },
+          Bas: {
+            path: "foos/:id/:nip",
+            parse: {
+              id: Number,
+              pwd: Number,
+            },
+          },
+        },
+      },
+    },
+  };
+
+  const state = {
+    routes: [
+      {
+        name: "Foe",
+        params: {
+          id: 5,
+        },
+
+        state: {
+          index: 1,
+          routes: [
+            {
+              name: "Foo",
+            },
+            {
+              name: "Bis",
+              params: { id: 5 },
+              path,
+            },
+          ],
+        },
+      },
+    ],
+  };
+
+  expect(getStateFromPath<object>(path, config)).toEqual(state);
+  expect(
+    getStateFromPath<object>(getPathFromState<object>(state, config), config)
+  ).toEqual(state);
+});
+
+it("handles differently ordered params v1", () => {
+  const path = "/foos/5/res/20";
+
+  const config = {
+    screens: {
+      Foe: {
+        path: "/",
+        initialRouteName: "Foo",
+        screens: {
+          Foo: "foo",
+          Bis: {
+            path: "foos/:id",
+            parse: {
+              id: Number,
+            },
+          },
+          Bas: {
+            path: "foos/:id/res/:pwd",
+            parse: {
+              id: Number,
+              pwd: Number,
+            },
+          },
+        },
+      },
+    },
+  };
+
+  const state = {
+    routes: [
+      {
+        name: "Foe",
+        params: {
+          id: 5,
+          pwd: 20,
+        },
+        state: {
+          index: 1,
+          routes: [
+            {
+              name: "Foo",
+            },
+            {
+              name: "Bas",
+              params: { id: 5, pwd: 20 },
+              path,
+            },
+          ],
+        },
+      },
+    ],
+  };
+
+  expect(getStateFromPath<object>(path, config)).toEqual(state);
+  expect(
+    getStateFromPath<object>(getPathFromState<object>(state, config), config)
+  ).toEqual(state);
+});
+
+it("handles differently ordered params v2", () => {
+  const path = "/5/20/foos/res";
+
+  const config = {
+    screens: {
+      Foe: {
+        path: "/",
+        initialRouteName: "Foo",
+        screens: {
+          Foo: "foo",
+          Bis: {
+            path: "foos/:id",
+            parse: {
+              id: Number,
+            },
+          },
+          Bas: {
+            path: ":id/:pwd/foos/res",
+            parse: {
+              id: Number,
+              pwd: Number,
+            },
+          },
+        },
+      },
+    },
+  };
+
+  const state = {
+    routes: [
+      {
+        name: "Foe",
+        params: {
+          id: 5,
+          pwd: 20,
+        },
+
+        state: {
+          index: 1,
+          routes: [
+            {
+              name: "Foo",
+            },
+            {
+              name: "Bas",
+              params: { id: 5, pwd: 20 },
+              path,
+            },
+          ],
+        },
+      },
+    ],
+  };
+
+  expect(getStateFromPath<object>(path, config)).toEqual(state);
+  expect(
+    getStateFromPath<object>(getPathFromState<object>(state, config), config)
+  ).toEqual(state);
+});
+
+it("handles differently ordered params v3", () => {
+  const path = "/foos/5/20/res";
+
+  const config = {
+    screens: {
+      Foe: {
+        path: "/",
+        initialRouteName: "Foo",
+        screens: {
+          Foo: "foo",
+          Bis: {
+            path: "foos/:id",
+            parse: {
+              id: Number,
+            },
+          },
+          Bas: {
+            path: "foos/:id/:pwd/res",
+            parse: {
+              id: Number,
+              pwd: Number,
+            },
+          },
+        },
+      },
+    },
+  };
+
+  const state = {
+    routes: [
+      {
+        name: "Foe",
+        params: {
+          id: 5,
+          pwd: 20,
+        },
+        state: {
+          index: 1,
+          routes: [
+            {
+              name: "Foo",
+            },
+            {
+              name: "Bas",
+              params: { id: 5, pwd: 20 },
+              path,
+            },
+          ],
+        },
+      },
+    ],
+  };
+
+  expect(getStateFromPath<object>(path, config)).toEqual(state);
+  expect(
+    getStateFromPath<object>(getPathFromState<object>(state, config), config)
+  ).toEqual(state);
+});
+
+it("handles differently ordered params v4", () => {
+  const path = "5/foos/res/20";
+
+  const config = {
+    screens: {
+      Foe: {
+        path: "/",
+        initialRouteName: "Foo",
+        screens: {
+          Foo: "foo",
+          Bis: {
+            path: "foos/:id",
+            parse: {
+              id: Number,
+            },
+          },
+          Bas: {
+            path: ":id/foos/res/:pwd",
+            parse: {
+              id: Number,
+              pwd: Number,
+            },
+          },
+        },
+      },
+    },
+  };
+
+  const state = {
+    routes: [
+      {
+        name: "Foe",
+        params: {
+          id: 5,
+          pwd: 20,
+        },
+        state: {
+          index: 1,
+          routes: [
+            {
+              name: "Foo",
+            },
+            {
+              name: "Bas",
+              params: { id: 5, pwd: 20 },
+              path,
+            },
+          ],
+        },
+      },
+    ],
+  };
+
+  expect(getStateFromPath<object>(path, config)).toEqual(state);
+  expect(
+    getStateFromPath<object>(getPathFromState<object>(state, config), config)
+  ).toEqual(changePath(state, "/5/foos/res/20"));
+});
+
+it("handles simple optional params", () => {
+  const path = "/foos/5";
+
+  const config = {
+    screens: {
+      Foe: {
+        path: "/",
+        initialRouteName: "Foo",
+        screens: {
+          Foo: "foo",
+          Bis: {
+            path: "foo/:id",
+            parse: {
+              id: Number,
+            },
+          },
+          Bas: {
+            path: "foos/:id/:nip?",
+            parse: {
+              id: Number,
+              nip: Number,
+            },
+          },
+        },
+      },
+    },
+  };
+
+  const state = {
+    routes: [
+      {
+        name: "Foe",
+        params: {
+          id: 5,
+        },
+        state: {
+          index: 1,
+          routes: [
+            {
+              name: "Foo",
+            },
+            {
+              name: "Bas",
+              params: { id: 5 },
+              path,
+            },
+          ],
+        },
+      },
+    ],
+  };
+
+  expect(getStateFromPath<object>(path, config)).toEqual(state);
+  expect(
+    getStateFromPath<object>(getPathFromState<object>(state, config), config)
+  ).toEqual(state);
+});
+
+it("handle 2 optional params at the end v1", () => {
+  const path = "/foos/5";
+
+  const config = {
+    screens: {
+      Foe: {
+        path: "/",
+        initialRouteName: "Foo",
+        screens: {
+          Foo: "foo",
+          Bis: {
+            path: "foo/:id",
+            parse: {
+              id: Number,
+            },
+          },
+          Bas: {
+            path: "foos/:id/:nip?/:pwd?",
+            parse: {
+              id: Number,
+              nip: Number,
+            },
+          },
+        },
+      },
+    },
+  };
+
+  const state = {
+    routes: [
+      {
+        name: "Foe",
+        params: {
+          id: 5,
+        },
+        state: {
+          index: 1,
+          routes: [
+            {
+              name: "Foo",
+            },
+            {
+              name: "Bas",
+              params: { id: 5 },
+              path,
+            },
+          ],
+        },
+      },
+    ],
+  };
+
+  expect(getStateFromPath<object>(path, config)).toEqual(state);
+  expect(
+    getStateFromPath<object>(getPathFromState<object>(state, config), config)
+  ).toEqual(state);
+});
+
+it("handle 2 optional params at the end v2", () => {
+  const path = "/foos/5/10";
+
+  const config = {
+    screens: {
+      Foe: {
+        path: "/",
+        initialRouteName: "Foo",
+        screens: {
+          Foo: "foo",
+          Bis: {
+            path: "foo/:id",
+            parse: {
+              id: Number,
+            },
+          },
+          Bas: {
+            path: "foos/:id/:nip?/:pwd?",
+            parse: {
+              id: Number,
+              nip: Number,
+            },
+          },
+        },
+      },
+    },
+  };
+
+  const state = {
+    routes: [
+      {
+        name: "Foe",
+        params: {
+          id: 5,
+          nip: 10,
+        },
+
+        state: {
+          index: 1,
+          routes: [
+            {
+              name: "Foo",
+            },
+            {
+              name: "Bas",
+              params: { id: 5, nip: 10 },
+              path,
+            },
+          ],
+        },
+      },
+    ],
+  };
+
+  expect(getStateFromPath<object>(path, config)).toEqual(state);
+  expect(
+    getStateFromPath<object>(getPathFromState<object>(state, config), config)
+  ).toEqual(state);
+});
+
+it("handle 2 optional params at the end v3", () => {
+  const path = "/foos/5/10/15";
+
+  const config = {
+    screens: {
+      Foe: {
+        path: "/",
+        initialRouteName: "Foo",
+        screens: {
+          Foo: "foo",
+          Bis: {
+            path: "foo/:id",
+            parse: {
+              id: Number,
+            },
+          },
+          Bas: {
+            path: "foos/:id/:nip?/:pwd?",
+            parse: {
+              id: Number,
+              nip: Number,
+              pwd: Number,
+            },
+          },
+        },
+      },
+    },
+  };
+
+  const state = {
+    routes: [
+      {
+        name: "Foe",
+        params: {
+          nip: 10,
+          pwd: 15,
+          id: 5,
+        },
+        state: {
+          index: 1,
+          routes: [
+            {
+              name: "Foo",
+            },
+            {
+              name: "Bas",
+              params: { id: 5, nip: 10, pwd: 15 },
+              path,
+            },
+          ],
+        },
+      },
+    ],
+  };
+
+  expect(getStateFromPath<object>(path, config)).toEqual(state);
+  expect(
+    getStateFromPath<object>(getPathFromState<object>(state, config), config)
+  ).toEqual(state);
+});
+
+it("handle optional params in the middle v1", () => {
+  const path = "/foos/5/10";
+
+  const config = {
+    screens: {
+      Foe: {
+        path: "/",
+        initialRouteName: "Foo",
+        screens: {
+          Foo: "foo",
+          Bis: {
+            path: "foo/:id",
+            parse: {
+              id: Number,
+            },
+          },
+          Bas: {
+            path: "foos/:id/:nip?/:pwd",
+            parse: {
+              id: Number,
+              nip: Number,
+              pwd: Number,
+            },
+          },
+        },
+      },
+    },
+  };
+
+  const state = {
+    routes: [
+      {
+        name: "Foe",
+        params: {
+          id: 5,
+          pwd: 10,
+        },
+
+        state: {
+          index: 1,
+          routes: [
+            {
+              name: "Foo",
+            },
+            {
+              name: "Bas",
+              params: { id: 5, pwd: 10 },
+              path,
+            },
+          ],
+        },
+      },
+    ],
+  };
+
+  expect(getStateFromPath<object>(path, config)).toEqual(state);
+  expect(
+    getStateFromPath<object>(getPathFromState<object>(state, config), config)
+  ).toEqual(state);
+});
+
+it("handle optional params in the middle v2", () => {
+  const path = "/foos/5/10/15";
+
+  const config = {
+    screens: {
+      Foe: {
+        path: "/",
+        initialRouteName: "Foo",
+        screens: {
+          Foo: "foo",
+          Bis: {
+            path: "foo/:id",
+            parse: {
+              id: Number,
+            },
+          },
+          Bas: {
+            path: "foos/:id/:nip?/:pwd",
+            parse: {
+              id: Number,
+              nip: Number,
+              pwd: Number,
+            },
+          },
+        },
+      },
+    },
+  };
+
+  const state = {
+    routes: [
+      {
+        name: "Foe",
+        params: {
+          id: 5,
+          nip: 10,
+          pwd: 15,
+        },
+        state: {
+          index: 1,
+          routes: [
+            {
+              name: "Foo",
+            },
+            {
+              name: "Bas",
+              params: { id: 5, nip: 10, pwd: 15 },
+              path,
+            },
+          ],
+        },
+      },
+    ],
+  };
+
+  expect(getStateFromPath<object>(path, config)).toEqual(state);
+  expect(
+    getStateFromPath<object>(getPathFromState<object>(state, config), config)
+  ).toEqual(state);
+});
+
+it("handle optional params in the middle v3", () => {
+  const path = "/foos/5/10/15";
+
+  const config = {
+    screens: {
+      Foe: {
+        path: "/",
+        initialRouteName: "Foo",
+        screens: {
+          Foo: "foo",
+          Bis: {
+            path: "foo/:id",
+            parse: {
+              id: Number,
+            },
+          },
+          Bas: {
+            path: "foos/:id/:nip?/:pwd/:smh",
+            parse: {
+              id: Number,
+              nip: Number,
+              pwd: Number,
+              smh: Number,
+            },
+          },
+        },
+      },
+    },
+  };
+
+  const state = {
+    routes: [
+      {
+        name: "Foe",
+        params: {
+          id: 5,
+          pwd: 10,
+          smh: 15,
+        },
+
+        state: {
+          index: 1,
+          routes: [
+            {
+              name: "Foo",
+            },
+            {
+              name: "Bas",
+              params: { id: 5, pwd: 10, smh: 15 },
+              path,
+            },
+          ],
+        },
+      },
+    ],
+  };
+
+  expect(getStateFromPath<object>(path, config)).toEqual(state);
+  expect(
+    getStateFromPath<object>(getPathFromState<object>(state, config), config)
+  ).toEqual(state);
+});
+
+it("handle optional params in the middle v4", () => {
+  const path = "/foos/5/10";
+
+  const config = {
+    screens: {
+      Foe: {
+        path: "/",
+        initialRouteName: "Foo",
+        screens: {
+          Foo: "foo",
+          Bis: {
+            path: "foo/:id",
+            parse: {
+              id: Number,
+            },
+          },
+          Bas: {
+            path: "foos/:nip?/:pwd/:smh?/:id",
+            parse: {
+              id: Number,
+              nip: Number,
+              pwd: Number,
+              smh: Number,
+            },
+          },
+        },
+      },
+    },
+  };
+
+  const state = {
+    routes: [
+      {
+        name: "Foe",
+        params: {
+          id: 10,
+          pwd: 5,
+        },
+        state: {
+          index: 1,
+          routes: [
+            {
+              name: "Foo",
+            },
+            {
+              name: "Bas",
+              params: { pwd: 5, id: 10 },
+              path,
+            },
+          ],
+        },
+      },
+    ],
+  };
+
+  expect(getStateFromPath<object>(path, config)).toEqual(state);
+  expect(
+    getStateFromPath<object>(getPathFromState<object>(state, config), config)
+  ).toEqual(state);
+});
+
+it("handle optional params in the middle v5", () => {
+  const path = "/foos/5/10/15";
+
+  const config = {
+    screens: {
+      Foe: {
+        path: "/",
+        initialRouteName: "Foo",
+        screens: {
+          Foo: "foo",
+          Bis: {
+            path: "foo/:id",
+            parse: {
+              id: Number,
+            },
+          },
+          Bas: {
+            path: "foos/:nip?/:pwd/:smh?/:id",
+            parse: {
+              id: Number,
+              nip: Number,
+              pwd: Number,
+              smh: Number,
+            },
+          },
+        },
+      },
+    },
+  };
+
+  const state = {
+    routes: [
+      {
+        name: "Foe",
+        params: {
+          id: 15,
+          nip: 5,
+          pwd: 10,
+        },
+
+        state: {
+          index: 1,
+          routes: [
+            {
+              name: "Foo",
+            },
+            {
+              name: "Bas",
+              params: { nip: 5, pwd: 10, id: 15 },
+              path,
+            },
+          ],
+        },
+      },
+    ],
+  };
+
+  expect(getStateFromPath<object>(path, config)).toEqual(state);
+  expect(
+    getStateFromPath<object>(getPathFromState<object>(state, config), config)
+  ).toEqual(state);
+});
+
+it("handle optional params in the beginning v1", () => {
+  const path = "5/10/foos/15";
+
+  const config = {
+    screens: {
+      Foe: {
+        path: "/",
+        initialRouteName: "Foo",
+        screens: {
+          Foo: "foo",
+          Bis: {
+            path: "foo/:id",
+            parse: {
+              id: Number,
+            },
+          },
+          Bas: {
+            path: ":nip?/:pwd/foos/:smh?/:id",
+            parse: {
+              id: Number,
+              nip: Number,
+              pwd: Number,
+              smh: Number,
+            },
+          },
+        },
+      },
+    },
+  };
+
+  const state = {
+    routes: [
+      {
+        name: "Foe",
+        params: {
+          id: 15,
+          nip: 5,
+          pwd: 10,
+        },
+        state: {
+          index: 1,
+          routes: [
+            {
+              name: "Foo",
+            },
+            {
+              name: "Bas",
+              params: { nip: 5, pwd: 10, id: 15 },
+              path,
+            },
+          ],
+        },
+      },
+    ],
+  };
+
+  expect(getStateFromPath<object>(path, config)).toEqual(state);
+  expect(
+    getStateFromPath<object>(getPathFromState<object>(state, config), config)
+  ).toEqual(changePath(state, "/5/10/foos/15"));
+});
+
+it("handle optional params in the beginning v2", () => {
+  const path = "5/10/foos/15";
+
+  const config = {
+    screens: {
+      Foe: {
+        path: "/",
+        initialRouteName: "Foo",
+        screens: {
+          Foo: "foo",
+          Bis: {
+            path: "foo/:id",
+            parse: {
+              id: Number,
+            },
+          },
+          Bas: {
+            path: ":nip?/:smh?/:pwd/foos/:id",
+            parse: {
+              id: Number,
+              nip: Number,
+              pwd: Number,
+              smh: Number,
+            },
+          },
+        },
+      },
+    },
+  };
+
+  const state = {
+    routes: [
+      {
+        name: "Foe",
+        params: {
+          id: 15,
+          nip: 5,
+          pwd: 10,
+        },
+        state: {
+          index: 1,
+          routes: [
+            {
+              name: "Foo",
+            },
+            {
+              name: "Bas",
+              params: { nip: 5, pwd: 10, id: 15 },
+              path,
+            },
+          ],
+        },
+      },
+    ],
+  };
+
+  expect(getStateFromPath<object>(path, config)).toEqual(state);
+  expect(
+    getStateFromPath<object>(getPathFromState<object>(state, config), config)
+  ).toEqual(changePath(state, "/5/10/foos/15"));
+});
+
+it("merges parent patterns if needed", () => {
+  const path = "foo/42/baz/babel";
+
+  const config = {
+    screens: {
+      Foo: {
+        path: "foo/:bar",
+        parse: {
+          bar: Number,
+        },
+        screens: {
+          Baz: "baz/:qux",
+        },
+      },
+    },
+  };
+
+  const state = {
+    routes: [
+      {
+        name: "Foo",
+        params: { bar: 42, qux: "babel" },
+        state: {
+          routes: [
+            {
+              name: "Baz",
+              params: { bar: 42, qux: "babel" },
+              path,
+            },
+          ],
+        },
+      },
+    ],
+  };
+
+  expect(getStateFromPath<object>(path, config)).toEqual(state);
+  expect(
+    getStateFromPath<object>(getPathFromState<object>(state, config), config)
+  ).toEqual(changePath(state, "/foo/42/baz/babel"));
+});
+
+it("ignores extra slashes in the pattern", () => {
+  const path = "/bar/42";
+  const config = {
+    screens: {
+      Foo: {
+        screens: {
+          Bar: {
+            path: "/bar//:id/",
+          },
+        },
+      },
+    },
+  };
+
+  const state = {
+    routes: [
+      {
+        name: "Foo",
+        params: {
+          id: "42",
+        },
+        state: {
+          routes: [
+            {
+              name: "Bar",
+              params: { id: "42" },
+              path,
+            },
+          ],
+        },
+      },
+    ],
+  };
+
+  expect(getStateFromPath<object>(path, config)).toEqual(state);
+  expect(
+    getStateFromPath<object>(getPathFromState<object>(state, config), config)
+  ).toEqual(state);
+});
+
+it("matches wildcard patterns at root", () => {
+  const path = "/test/bar/42/whatever";
+  const config = {
+    screens: {
+      404: "*",
+      Foo: {
+        screens: {
+          Bar: {
+            path: "/bar/:id/",
+          },
+        },
+      },
+    },
+  };
+
+  const state = {
+    routes: [{ name: "404", path }],
+  };
+
+  expect(getStateFromPath<object>(path, config)).toEqual(state);
+  expect(
+    getStateFromPath<object>(getPathFromState<object>(state, config), config)
+  ).toEqual(state);
+});
+
+it("matches wildcard patterns at nested level", () => {
+  const path = "/bar/42/whatever/baz/initt";
+  const config = {
+    screens: {
+      "(foo)": {
+        path: "",
+        screens: {
+          bar: {
+            path: "bar",
+            screens: {
+              "[id]": ":id",
+              "[...404]": "*",
+            },
+          },
+        },
+      },
+    },
+  };
+
+  const state = {
+    routes: [
+      {
+        name: "(foo)",
+        state: {
+          routes: [
+            {
+              name: "bar",
+              state: {
+                routes: [
+                  { name: "[...404]", path: "/bar/42/whatever/baz/initt" },
+                ],
+              },
+            },
+          ],
+        },
+      },
+    ],
+  };
+
+  expect(getStateFromPath<object>(path, config)).toEqual(state);
+  expect(
+    getStateFromPath<object>(getPathFromState<object>(state, config), config)
+  ).toEqual(state);
+});
+
+it("matches wildcard patterns at nested level with exact", () => {
+  const path = "/whatever";
+  const config = {
+    screens: {
+      Foo: {
+        screens: {
+          Bar: {
+            path: "/bar/:id/",
+            screens: {
+              404: {
+                path: "*",
+                exact: true,
+              },
+            },
+          },
+          Baz: {},
+        },
+      },
+    },
+  };
+
+  const state = {
+    routes: [
+      {
+        name: "Foo",
+        state: {
+          routes: [
+            {
+              name: "Bar",
+              state: {
+                routes: [{ name: "404", path }],
+              },
+            },
+          ],
+        },
+      },
+    ],
+  };
+
+  expect(getStateFromPath<object>(path, config)).toEqual(state);
+  expect(
+    getStateFromPath<object>(getPathFromState<object>(state, config), config)
+  ).toEqual(changePath(state, path));
+});
+
+it("tries to match wildcard patterns at the end", () => {
+  const path = "/bar/42/test";
+  const config = {
+    screens: {
+      bar: {
+        path: "bar",
+        screens: {
+          "[...404]": "*",
+          "[userSlug]": ":userSlug",
+          ":id": {
+            path: ":id",
+            screens: {
+              test: "test",
+            },
+          },
+        },
+      },
+    },
+  };
+
+  const state = {
+    routes: [
+      {
+        name: "bar",
+        params: { id: "42" },
+        state: {
+          routes: [
+            {
+              name: ":id",
+              params: { id: "42" },
+              state: {
+                routes: [
+                  {
+                    name: "test",
+                    params: { id: "42" },
+                    path: "/bar/42/test",
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      },
+    ],
+  };
+
+  expect(getStateFromPath<object>(path, config)).toEqual(state);
+  expect(
+    getStateFromPath<object>(getPathFromState<object>(state, config), config)
+  ).toEqual(state);
+});
+
+it("uses nearest parent wildcard match for unmatched paths", () => {
+  const path = "/bar/42/baz/test";
+  const config = {
+    screens: {
+      Foo: {
+        screens: {
+          Bar: {
+            path: "/bar/:id/",
+            screens: {
+              Baz: "baz",
+            },
+          },
+          404: "*",
+        },
+      },
+    },
+  };
+
+  const state = {
+    routes: [
+      {
+        name: "Foo",
+        state: {
+          routes: [{ name: "404", path }],
+        },
+      },
+    ],
+  };
+
+  expect(getStateFromPath<object>(path, config)).toEqual(state);
+  expect(
+    getStateFromPath<object>(getPathFromState<object>(state, config), config)
+  ).toEqual(state);
+});
+
+it("throws if two screens map to the same pattern", () => {
+  const path = "/bar/42/baz/test";
+
+  expect(() =>
+    getStateFromPath<object>(path, {
+      screens: {
+        Foo: {
+          screens: {
+            Bar: {
+              path: "/bar/:id/",
+              screens: {
+                Baz: "baz",
+              },
+            },
+            Bax: "/bar/:id/baz",
+          },
+        },
+      },
+    })
+  ).toThrow(
+    "The route pattern 'bar/:id/baz' resolves to both 'Foo//bar/:id/baz' and 'Foo/Bar/baz'. Patterns must be unique and cannot resolve to more than one route."
+  );
+
+  expect(() =>
+    getStateFromPath<object>(path, {
+      screens: {
+        Foo: {
+          screens: {
+            Bar: {
+              path: "/bar/:id/",
+              screens: {
+                Baz: "",
+              },
+            },
+          },
+        },
+      },
+    })
+  ).not.toThrow();
+});
+
+it("correctly applies initialRouteName for config with similar route names", () => {
+  const path = "/weekly-earnings";
+
+  const config = {
+    screens: {
+      RootTabs: {
+        screens: {
+          HomeTab: {
+            screens: {
+              Home: "",
+              WeeklyEarnings: "weekly-earnings",
+              EventDetails: "event-details/:eventId",
+            },
+          },
+          EarningsTab: {
+            initialRouteName: "Earnings",
+            path: "earnings",
+            screens: {
+              Earnings: "",
+              WeeklyEarnings: "weekly-earnings",
+            },
+          },
+        },
+      },
+    },
+  };
+
+  const state = {
+    routes: [
+      {
+        name: "RootTabs",
+        state: {
+          routes: [
+            {
+              name: "HomeTab",
+              state: {
+                routes: [
+                  {
+                    name: "WeeklyEarnings",
+                    path,
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      },
+    ],
+  };
+
+  expect(getStateFromPath<object>(path, config)).toEqual(state);
+  expect(
+    getStateFromPath<object>(getPathFromState<object>(state, config), config)
+  ).toEqual(state);
+});
+
+it("correctly applies initialRouteName for config with similar route names v2", () => {
+  const path = "/earnings/weekly-earnings";
+
+  const config = {
+    screens: {
+      RootTabs: {
+        screens: {
+          HomeTab: {
+            initialRouteName: "Home",
+            screens: {
+              Home: "",
+              WeeklyEarnings: "weekly-earnings",
+            },
+          },
+          EarningsTab: {
+            initialRouteName: "Earnings",
+            path: "earnings",
+            screens: {
+              Earnings: "",
+              WeeklyEarnings: "weekly-earnings",
+            },
+          },
+        },
+      },
+    },
+  };
+
+  const state = {
+    routes: [
+      {
+        name: "RootTabs",
+        state: {
+          routes: [
+            {
+              name: "EarningsTab",
+              state: {
+                index: 1,
+                routes: [
+                  {
+                    name: "Earnings",
+                  },
+                  {
+                    name: "WeeklyEarnings",
+                    path,
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      },
+    ],
+  };
+
+  expect(getStateFromPath<object>(path, config)).toEqual(state);
+  expect(
+    getStateFromPath<object>(getPathFromState<object>(state, config), config)
+  ).toEqual(state);
+});
+
+it("throws when invalid properties are specified in the config", () => {
+  expect(() =>
+    getStateFromPath<object>("", {
+      Foo: "foo",
+      Bar: {
+        path: "bar",
+      },
+    } as any)
+  ).toThrowErrorMatchingInlineSnapshot(`
+    "Found invalid properties in the configuration:
+    - Foo
+    - Bar
+
+    Did you forget to specify them under a 'screens' property?
+
+    You can only specify the following properties:
+    - initialRouteName
+    - screens
+
+    See https://reactnavigation.org/docs/configuring-links for more details on how to specify a linking configuration."
+  `);
+
+  expect(() =>
+    getStateFromPath<object>("", {
+      screens: {
+        Foo: "foo",
+        Bar: {
+          path: "bar",
+        },
+        Baz: {
+          Qux: {
+            path: "qux",
+          },
+        },
+      },
+    } as any)
+  ).toThrowErrorMatchingInlineSnapshot(`
+    "Found invalid properties in the configuration:
+    - Qux
+
+    Did you forget to specify them under a 'screens' property?
+
+    You can only specify the following properties:
+    - initialRouteName
+    - screens
+    - path
+    - exact
+    - stringify
+    - parse
+
+    See https://reactnavigation.org/docs/configuring-links for more details on how to specify a linking configuration."
+  `);
+});

--- a/packages/expo-router/src/fork/__tests__/getStateFromPath-upstream.test.node.ts
+++ b/packages/expo-router/src/fork/__tests__/getStateFromPath-upstream.test.node.ts
@@ -2292,6 +2292,7 @@ it("matches wildcard patterns at root", () => {
 
 it("matches wildcard patterns at nested level", () => {
   const path = "/bar/42/whatever/baz/initt";
+
   const config = {
     screens: {
       "(foo)": {

--- a/packages/expo-router/src/fork/getPathFromState.ts
+++ b/packages/expo-router/src/fork/getPathFromState.ts
@@ -140,11 +140,6 @@ export default function getPathFromState<ParamList extends object>(
       nestedRouteNames.push(route.name);
 
       if (route.params) {
-        // NOTE(EvanBacon): Fill in current route using state that was passed as params.
-        if (!route.state && isInvalidParams(route.params)) {
-          current = createFakeState(route.params);
-        }
-
         const stringify = currentOptions[route.name]?.stringify;
 
         const currentParams = Object.fromEntries(

--- a/packages/expo-router/src/fork/getPathFromState.ts
+++ b/packages/expo-router/src/fork/getPathFromState.ts
@@ -209,15 +209,25 @@ export default function getPathFromState<ParamList extends object>(
     if (currentOptions[route.name] !== undefined) {
       path += pattern
         .split("/")
-        .map((p) => {
+        .map((p, i) => {
           const name = getParamName(p);
 
           // We don't know what to show for wildcard patterns
           // Showing the route name seems ok, though whatever we show here will be incorrect
           // Since the page doesn't actually exist
           if (p === "*") {
-            // This can occur when a wildcard matches all routes and the given path was `/`.
-            return route.path ?? "";
+            if (i === 0) {
+              // This can occur when a wildcard matches all routes and the given path was `/`.
+              return route.path ?? "";
+            }
+            // remove existing segments from route.path and return it
+            // this is used for nested wildcard routes. Without this, the path would add
+            // all nested segments to the beginning of the wildcard route.
+            const path = route.path
+              ?.split("/")
+              .slice(i + 1)
+              .join("/");
+            return path ?? "";
           }
 
           // If the path has a pattern for a param, put the param in the path

--- a/packages/expo-router/src/fork/getStateFromPath.ts
+++ b/packages/expo-router/src/fork/getStateFromPath.ts
@@ -376,11 +376,15 @@ const matchAgainstConfigs = (remaining: string, configs: RouteConfig[]) => {
         {}
       );
 
+      const hasCombinedParams = Object.keys(combinedParams).length > 0;
+
       // Combine all params so a route `[foo]/[bar]/other.js` has access to `{ foo, bar }`
-      routes = routes.map((r) => ({
-        ...r,
-        params: combinedParams,
-      }));
+      routes = routes.map((r) => {
+        if (hasCombinedParams) {
+          r.params = combinedParams;
+        }
+        return r;
+      });
 
       remainingPath = remainingPath.replace(match[1], "");
 
@@ -632,7 +636,12 @@ const createNestedStateObject = (
   );
 
   if (params) {
-    route.params = { ...route.params, ...params };
+    const resolvedParams = { ...route.params, ...params };
+    if (Object.keys(resolvedParams).length > 0) {
+      route.params = resolvedParams;
+    } else {
+      delete route.params;
+    }
   }
 
   return state;


### PR DESCRIPTION
- port upstream tests to ensure functionality continues to work
- add a patch for StackRouter which uses `query` to indicate the intended next state. This will ensure `statePath` works as expected in custom navigators.