### PR TITLE
Add initialRouteName to linking config

### DIFF
--- a/apps/demo/app/(root).tsx
+++ b/apps/demo/app/(root).tsx
@@ -1,15 +1,9 @@
-import { Children, Layout, NativeStack } from "expo-router";
+import { Stack } from "expo-router";
 
 export default function Root() {
   return (
-    <Layout>
-      <Inner />
-    </Layout>
+    <Stack screenOptions={{ headerShown: false }}>
+      <Stack.Screen name={"modal"} options={{ presentation: "modal" }} />
+    </Stack>
   );
-}
-function Inner() {
-  const { pathname, statePath } = Layout.useContext();
-
-  console.log("pathname", pathname, statePath);
-  return <Children />;
 }

--- a/apps/demo/app/(root)/(tab).js
+++ b/apps/demo/app/(root)/(tab).js
@@ -1,8 +1,8 @@
 import { Tabs } from "expo-router";
 export default function Layout1() {
   return (
-    <Tabs>
-      <Tabs.Screen name="settings" />
+    <Tabs initialRouteName={"index"}>
+      <Tabs.Screen name="settings" options={{ title: "Settings", headerShown: false }} />
     </Tabs>
   );
 }

--- a/packages/expo-router/src/getLinkingConfig.ts
+++ b/packages/expo-router/src/getLinkingConfig.ts
@@ -35,6 +35,20 @@ function convertDynamicRouteToReactNavigation(name: string) {
 
   return name;
 }
+function getInitialRouteNameFromNode(node) {
+  const regex = new RegExp('\\n\\s*initialRouteName:\\s"([^"]+)",\\n', "m");
+  const found = node.getComponent().toString().match(regex);
+  if (found) {
+    return found[1];
+  }
+  if (node.children?.length) {
+    if (node.children.find((item) => item.route === "index")) {
+      return "index";
+    }
+    return node.children[0].route;
+  }
+  return null;
+}
 
 export function treeToReactNavigationLinkingRoutes(
   nodes: RouteNode[],
@@ -55,7 +69,9 @@ export function treeToReactNavigationLinkingRoutes(
         path,
       ]);
 
-      return [node.route, { path, screens }] as const;
+      const initialRouteName = getInitialRouteNameFromNode(node);
+
+      return [node.route, { path, screens, initialRouteName }] as const;
     })
     .reduce<PathConfigMap<object>>((acc, [route, current]) => {
       acc[route] = current;

--- a/packages/expo-router/src/link/useLinkToPath.ts
+++ b/packages/expo-router/src/link/useLinkToPath.ts
@@ -19,6 +19,11 @@ export function useLinkToPath() {
         );
       }
 
+      if (to === "../") {
+        navigation.goBack();
+        return;
+      }
+
       if (!to.startsWith("/")) {
         if (/:\/\//.test(to)) {
           // Open external link


### PR DESCRIPTION
### Motivation:
#27, i need render modal as modal, if app starts from deep link. its possible and documented in [react-navigation docs](https://reactnavigation.org/docs/configuring-links/#rendering-an-initial-route) (issue [#8103](https://github.com/react-navigation/react-navigation/issues/8103)). for realization, need add `initialRouteName` to linking config (in demo app, when app starts from deep link `/--/modal`, initialRouteName need to be `(tab)` in parent `(root)` stack)

### PR:
* returned apps/demo to working state, sorry for that. its like we need some params in index.js, which of the directories to consider "app"
* fix `<Link href="../">`. in original [/src/link/useLinkToPath.ts](https://github.com/expo/router/blob/3500b4aae8a05e06ec0c5383f8610d5e9aa76a24/packages/expo-router/src/link/useLinkToPath.ts#L22) we have test like
```javascript
if (!to.startsWith("/")) {
  if (/:\/\//.test(to)) {
    // Open external link
    Linking.openURL(to);
    return;
  } else {
    throw new Error(
      `The href must start with '/' (${to}) or be a fully qualified URL.`
    );
  }
}
```
and error in console `The href must start with '/' (${to}) or be a fully qualified URL.`
* fix #27 by add `initialRouteName` to linking config. add method `getInitialRouteNameFromNode` to [/src/getLinkingConfig.ts](https://github.com/expo/router/blob/3500b4aae8a05e06ec0c5383f8610d5e9aa76a24/packages/expo-router/src/getLinkingConfig.ts)
```javascript
function getInitialRouteNameFromNode(node) {
  const regex = new RegExp('\\n\\s*initialRouteName:\\s"([^"]+)",\\n', "m");
  const found = node.getComponent().toString().match(regex);
  if (found) {
    return found[1];
  }
  if (node.children?.length) {
    if (node.children.find((item) => item.route === "index")) {
      return "index";
    }
    return node.children[0].route;
  }
  return null;
}
```
i know, its regex over `function().toString()`, but i dont known safe alternatives to get component props without compilate component (I don't have much experience with react api)

### Limitation: 
I noticed that in normal use, this pr doesnt affect default behavior. but if start app from deep link, like `/--/modal`, with configured `(tab).js` like
```javascript
return (
  <Tabs>
    <Tabs.Screen name="settings" options={{ title: "Settings", headerShown: false }} />
  </Tabs>
);
```
app load modal and after dismiss, i see `settings` screen, not index. and to fix it need set `initialRouteName` to Tabs
```javascript
return (
  <Tabs initialRouteName={"index"}>
    <Tabs.Screen name="settings" options={{ title: "Settings", headerShown: false }} />
  </Tabs>
);
```
after that the app will work as usual