### PR TITLE
feat: match deep dynamic routes and provide the params to the route

### DIFF
--- a/packages/expo-router/src/fork/__tests__/getStateFromPath-upstream.test.node.ts
+++ b/packages/expo-router/src/fork/__tests__/getStateFromPath-upstream.test.node.ts
@@ -2314,13 +2314,21 @@ it("matches wildcard patterns at nested level", () => {
     routes: [
       {
         name: "(foo)",
+        params: { "404": ["bar", "42", "whatever", "baz", "initt"] },
         state: {
           routes: [
             {
               name: "bar",
+              params: { "404": ["bar", "42", "whatever", "baz", "initt"] },
               state: {
                 routes: [
-                  { name: "[...404]", path: "/bar/42/whatever/baz/initt" },
+                  {
+                    name: "[...404]",
+                    params: {
+                      "404": ["bar", "42", "whatever", "baz", "initt"],
+                    },
+                    path: "/bar/42/whatever/baz/initt",
+                  },
                 ],
               },
             },

--- a/packages/expo-router/src/fork/getPathFromState.ts
+++ b/packages/expo-router/src/fork/getPathFromState.ts
@@ -9,6 +9,7 @@ import type {
   Route,
 } from "@react-navigation/routers";
 import * as queryString from "query-string";
+
 import { matchDeepDynamicRouteName } from "../matchers";
 
 type Options<ParamList extends object> = {

--- a/packages/expo-router/src/fork/getPathFromState.ts
+++ b/packages/expo-router/src/fork/getPathFromState.ts
@@ -9,6 +9,7 @@ import type {
   Route,
 } from "@react-navigation/routers";
 import * as queryString from "query-string";
+import { matchDeepDynamicRouteName } from "../matchers";
 
 type Options<ParamList extends object> = {
   initialRouteName?: string;
@@ -163,7 +164,13 @@ export default function getPathFromState<ParamList extends object>(
             .filter((p) => p.startsWith(":") || p === "*")
             // eslint-disable-next-line no-loop-func
             .forEach((p) => {
-              const name = getParamName(p);
+              let name: string;
+              if (p === "*") {
+                // NOTE(EvanBacon): Drop the param name matching the wildcard route name -- this is specific to Expo Router.
+                name = matchDeepDynamicRouteName(route.name) ?? route.name;
+              } else {
+                name = getParamName(p);
+              }
 
               // Remove the params present in the pattern since we'll only use the rest for query string
               if (focusedParams) {

--- a/packages/expo-router/src/fork/getStateFromPath.ts
+++ b/packages/expo-router/src/fork/getStateFromPath.ts
@@ -10,6 +10,7 @@ import type {
 } from "@react-navigation/routers";
 import escape from "escape-string-regexp";
 import * as queryString from "query-string";
+
 import { matchDeepDynamicRouteName } from "../matchers";
 
 //   import findFocusedRoute from './findFocusedRoute';
@@ -355,7 +356,7 @@ const matchAgainstConfigs = (remaining: string, configs: RouteConfig[]) => {
         const config = configs.find((c) => c.screen === name);
         const params = config?.path
           ?.split("/")
-          .filter((p) => p.startsWith(":") || "*" === p)
+          .filter((p) => p.startsWith(":") || p === "*")
           .reduce<Record<string, any>>((acc, p) => {
             const paramName = p;
             const value = matchedParams[paramName];


### PR DESCRIPTION
Currently, React Navigation will match the `:slug` value (dynamic route) and provide it as query parameters to the route:


```tsx
// app/[foobar].tsx -> app://something

function Page({ route }) {
  // route.params.foobar === 'something'
}
```

This PR introduces the same system for wildcard routes (not part of React Navigation). Here we utilize the screen name to provide parameters to the route:


```tsx
// app/[...foobar].tsx -> app://some/thing

function Page({ route }) {
  // route.params.foobar === ['some', 'thing']
}
```