### PR TITLE
fix: `<Link href="../">` 

### DIFF
--- a/apps/demo/app/(root)/(app)/[...bar].tsx
+++ b/apps/demo/app/(root)/(app)/[...bar].tsx
@@ -1,0 +1,3 @@
+import { Stack } from "expo-router";
+
+export default Stack;

--- a/apps/demo/app/(root)/(app)/[...bar]/index.js
+++ b/apps/demo/app/(root)/(app)/[...bar]/index.js
@@ -1,0 +1,44 @@
+import { Link, useLink } from "expo-router";
+import { StatusBar, StyleSheet, Text, View } from "react-native";
+
+export default function App({ navigation }) {
+	const link = useLink();
+
+	return (
+		<View style={styles.container}>
+			<Link href="../" style={{ fontSize: 24, fontWeight: "bold" }}>
+				Dismiss
+			</Link>
+			<Text
+				onPress={() => {
+
+					link.replace('/');
+				}}
+			>
+				Open settings dynamic
+			</Text>
+			<StatusBar barStyle="light-content" />
+			{navigation.canGoBack() ? (
+				<Text>Can go back</Text>
+			) : (
+				<Text>Can't go back</Text>
+			)}
+			<Link
+				style={{ marginTop: 20, padding: 20, borderWidth: 2, borderColor: "black" }}
+				href={"/orders"}
+			>
+				GoTo Orders
+			</Link>
+		</View>
+	);
+}
+
+const styles = StyleSheet.create({
+	container: {
+		flex: 1,
+		padding: 20,
+		backgroundColor: "#fff",
+		alignItems: "center",
+		justifyContent: "center"
+	},
+});

--- a/apps/demo/app/(root)/(app)/[...bar]/orders.js
+++ b/apps/demo/app/(root)/(app)/[...bar]/orders.js
@@ -1,0 +1,45 @@
+import { Link, useLink } from "expo-router";
+import { StatusBar, StyleSheet, Text, View } from "react-native";
+
+export default function App({ navigation }) {
+	const link = useLink();
+
+	return (
+		<View style={styles.container}>
+			<Link href="../" style={{ fontSize: 24, fontWeight: "bold" }}>
+				Dismiss
+			</Link>
+			<Text
+				onPress={() => {
+
+					link.replace('/');
+				}}
+			>
+				Open settings dynamic
+			</Text>
+			<StatusBar barStyle="light-content" />
+			{navigation.canGoBack() ? (
+				<Text>Can go back</Text>
+			) : (
+				<Text>Can't go back</Text>
+			)}
+			<Link
+				style={{ marginTop: 20, padding: 20, borderWidth: 2, borderColor: "black" }}
+				/*href={"/test"}*/
+				href={"../"}
+			>
+				GoTo Back
+			</Link>
+		</View>
+	);
+}
+
+const styles = StyleSheet.create({
+	container: {
+		flex: 1,
+		padding: 20,
+		backgroundColor: "#fff",
+		alignItems: "center",
+		justifyContent: "center"
+	},
+});

--- a/apps/demo/app/(root)/(app)/[foo].tsx
+++ b/apps/demo/app/(root)/(app)/[foo].tsx
@@ -18,9 +18,9 @@ export default function App({ navigation }) {
       </Text>
       <StatusBar barStyle="light-content" />
       {navigation.canGoBack() ? (
-        <span>Can go back</span>
+        <Text>Can go back</Text>
       ) : (
-        <span>Can't go back</span>
+        <Text>Can't go back</Text>
       )}
     </View>
   );
@@ -32,5 +32,6 @@ const styles = StyleSheet.create({
     padding: 20,
     backgroundColor: "#fff",
     alignItems: "center",
+    justifyContent: "center"
   },
 });

--- a/apps/demo/app/(root)/(app)/index.tsx
+++ b/apps/demo/app/(root)/(app)/index.tsx
@@ -1,5 +1,6 @@
 import { StyleSheet, Text, View } from "react-native";
 import { GoogleAuth } from "../../../etc/auth/google";
+import { Link } from "expo-router";
 
 export default function App() {
   const signOut = GoogleAuth.useSignOut();
@@ -13,6 +14,13 @@ export default function App() {
       >
         Sign out
       </Text>
+
+      <Link
+        style={{ marginTop: 20, padding: 20, borderWidth: 2, borderColor: "black" }}
+        href={"/test"}
+      >
+        GoTo Foo
+      </Link>
     </View>
   );
 }

--- a/apps/demo/app/(root)/(app)/index.tsx
+++ b/apps/demo/app/(root)/(app)/index.tsx
@@ -1,9 +1,10 @@
 import { StyleSheet, Text, View } from "react-native";
 import { GoogleAuth } from "../../../etc/auth/google";
-import { Link } from "expo-router";
+import {Link, useLink} from "expo-router";
 
 export default function App() {
   const signOut = GoogleAuth.useSignOut();
+  const link = useLink();
 
   return (
     <View style={styles.container}>
@@ -15,12 +16,13 @@ export default function App() {
         Sign out
       </Text>
 
-      <Link
+      <Text
         style={{ marginTop: 20, padding: 20, borderWidth: 2, borderColor: "black" }}
-        href={"/test"}
+        /*href={"/test"}*/
+        onPress={() => link.replace('/test/ololo')}
       >
         GoTo Foo
-      </Link>
+      </Text>
     </View>
   );
 }

--- a/packages/expo-router/src/link/__tests__/normalizePath.test.node.ts
+++ b/packages/expo-router/src/link/__tests__/normalizePath.test.node.ts
@@ -1,0 +1,16 @@
+import { normalizePath } from "../href";
+
+describe(normalizePath, () => {
+  it(`normalize paths`, () => {
+    expect(normalizePath("foobar")).toBe("/foobar");
+    expect(normalizePath("foobar/")).toBe("/foobar");
+    expect(normalizePath("/foobar")).toBe("/foobar");
+    expect(normalizePath("/foo/bar")).toBe("/foo/bar");
+    expect(normalizePath("/foo/../bar")).toBe("/bar");
+    expect(normalizePath("/foo/../../../../bar")).toBe("/bar");
+    expect(normalizePath("/foo/../bar/./")).toBe("/bar");
+    expect(normalizePath("Tot4lly Wr0n9")).toBe("/Tot4lly Wr0n9");
+    expect(normalizePath("Tot4lly/../Wr0n9")).toBe("/Wr0n9");
+    expect(normalizePath("Tot4lly/./Wr0n9")).toBe("/Tot4lly/Wr0n9");
+  });
+});

--- a/packages/expo-router/src/link/href.ts
+++ b/packages/expo-router/src/link/href.ts
@@ -42,3 +42,14 @@ function createQuery(query: Record<string, any>) {
     .map((key) => `${key}=${query[key]}`)
     .join("&");
 }
+export function normalizePath(path: string): string {
+  const result: string[] = [];
+  const parts = path.split("/");
+  parts.forEach((part: string) => {
+    if (part === "") return;
+    if (part === ".") return;
+    if (part === "..") return result.pop();
+    return result.push(part);
+  });
+  return ["", ...result].join("/");
+}

--- a/packages/expo-router/src/link/useLinkToPath.ts
+++ b/packages/expo-router/src/link/useLinkToPath.ts
@@ -7,9 +7,13 @@ import { LinkingContext } from "@react-navigation/native";
 import * as React from "react";
 import { Linking } from "react-native";
 
+import { useCurrentRoute } from "../useCurrentRoute";
+import { normalizePath } from "./href";
+
 export function useLinkToPath() {
   const navigation = React.useContext(NavigationContainerRefContext);
   const linking = React.useContext(LinkingContext);
+  const current = useCurrentRoute();
 
   const linkTo = React.useCallback(
     (to: string, event?: string) => {
@@ -25,9 +29,12 @@ export function useLinkToPath() {
           Linking.openURL(to);
           return;
         } else {
-          throw new Error(
-            `The href must start with '/' (${to}) or be a fully qualified URL.`
-          );
+          // if relative, need append to current
+          if (to.startsWith("../") || to.startsWith("./")) {
+            to = current + "/" + to;
+          }
+          // normalize path, e.g. `/aaa/bbb/././//../ccc/` -> `/aaa/ccc/`
+          to = normalizePath(to);
         }
       }
 

--- a/packages/expo-router/src/link/useLinkToPath.ts
+++ b/packages/expo-router/src/link/useLinkToPath.ts
@@ -17,26 +17,23 @@ export function useLinkToPath() {
 
   const linkTo = React.useCallback(
     (to: string, event?: string) => {
+      if (current === null && event !== "REPLACE") return;
       if (navigation === undefined) {
         throw new Error(
           "Couldn't find a navigation object. Is your component inside NavigationContainer?"
         );
       }
 
-      if (!to.startsWith("/")) {
-        if (/:\/\//.test(to)) {
-          // Open external link
-          Linking.openURL(to);
-          return;
-        } else {
-          // if relative, need append to current
-          if (to.startsWith("../") || to.startsWith("./")) {
-            to = current + "/" + to;
-          }
-          // normalize path, e.g. `/aaa/bbb/././//../ccc/` -> `/aaa/ccc/`
-          to = normalizePath(to);
-        }
+      // if external -- go away ;(
+      if (/:\/\//.test(to)) return Linking.openURL(to);
+
+      // if relative, need append to current
+      if (to.startsWith("../") || to.startsWith("./")) {
+        to = current + "/" + to;
       }
+
+      // normalize path, e.g. `/aaa/bbb/././//../ccc/` -> `/aaa/ccc/`
+      to = normalizePath(to);
 
       const { options } = linking;
 
@@ -60,7 +57,7 @@ export function useLinkToPath() {
         throw new Error("Failed to parse the path to a navigation state.");
       }
     },
-    [linking, navigation]
+    [linking, navigation, current]
   );
 
   return linkTo;

--- a/packages/expo-router/src/link/useLinkToPath.ts
+++ b/packages/expo-router/src/link/useLinkToPath.ts
@@ -16,6 +16,8 @@ export function useLinkToPath() {
   const current = useCurrentRoute();
 
   const linkTo = React.useCallback(
+    // @ts-ignore
+    // it is for sugar like `return Linking.openURL(to);`
     (to: string, event?: string) => {
       if (current === null && event !== "REPLACE") return;
       if (navigation === undefined) {

--- a/packages/expo-router/src/useCurrentRoute.ts
+++ b/packages/expo-router/src/useCurrentRoute.ts
@@ -18,3 +18,18 @@ export function useRootNavigation() {
   }
   return context.ref;
 }
+
+export function useCurrentRoute() {
+  const context = React.useContext(RootNavigationRef);
+  if (!context) {
+    throw new Error(
+      "useCurrentRoute must be used within a NavigationContainerContext"
+    );
+  }
+  const root = useRootNavigation();
+  let path = root?.getCurrentRoute()?.path;
+  if (!path?.startsWith("/")) {
+    path = "/" + path;
+  }
+  return path;
+}

--- a/packages/expo-router/src/useCurrentRoute.ts
+++ b/packages/expo-router/src/useCurrentRoute.ts
@@ -20,15 +20,11 @@ export function useRootNavigation() {
 }
 
 export function useCurrentRoute() {
-  const context = React.useContext(RootNavigationRef);
-  if (!context) {
-    throw new Error(
-      "useCurrentRoute must be used within a NavigationContainerContext"
-    );
-  }
   const root = useRootNavigation();
   let path = root?.getCurrentRoute()?.path;
-  if (!path?.startsWith("/")) {
+  if (path === undefined) return null;
+
+  if (!path.startsWith("/")) {
     path = "/" + path;
   }
   return path;


### PR DESCRIPTION
at now `<Link href="../">` didnt work, because [/src/link/useLinkToPath.ts](https://github.com/expo/router/blob/12a53bd2919ae81dd52ead389ca239020416e3cb/packages/expo-router/src/link/useLinkToPath.ts#L22) has a strong comparison:
```javascript
if (!to.startsWith("/")) {
  if (/:\/\//.test(to)) {
    // Open external link
    Linking.openURL(to);
    return;
  } else {
    throw new Error(
      `The href must start with '/' (${to}) or be a fully qualified URL.`
    );
  }
}
```
and if we try `<Link href="../" />`, we got exception `The href must start with '/' (${to}) or be a fully qualified URL.`

### suggestions:
* attach relative path to the current. 
```javascript
if (to.startsWith("../") || to.startsWith("./")) {
  to = current + "/" + to;
}
```
*  and normalize all links (non-external, of course). as a last resort, the user will get a 404 but not an exception.

for convenience i add `useCurrentRoute` with some sugar, like add first `/` to the path, if not. this is for if we start app from deep link, like `exp://127.0.0.1:19000/--/test`, by default `getCurrentRoute().path` will be `test`, not `/test`. `useCurrentRoute` always return current path like `/test` or `/` or `/profile?name=smith`.

`normalizePath` method i put to `/src/link/href.ts`, mb he doesn't belong there.