### PR TITLE
docs: typo fix for migration guide

### DIFF
--- a/docs/docs/guides/index.md
+++ b/docs/docs/guides/index.md
@@ -17,7 +17,7 @@ export default function Layout() {
 Now create a **child route** in `app/(stack)/index.js` which will be rendered inside the stack navigator.
 
 ```js title=app/(stack)/index.js
-import { View, Text } from "react-native";
+import { View } from "react-native";
 import { Link, Stack } from "expo-router";
 
 export default function Home() {

--- a/docs/docs/migration/from-react-navigation.md
+++ b/docs/docs/migration/from-react-navigation.md
@@ -37,7 +37,7 @@ Expo Router wraps React Navigation APIs and re-exports them with light-weight co
 
 ```tsx
 // No: This is a React Navigation API.
-import { createStackNavigator } from "@react-navigation/natove-stack";
+import { createStackNavigator } from "@react-navigation/native-stack";
 
 const Stack = createStackNavigator();
 


### PR DESCRIPTION
Cleans up typo in the React Navigation migration guide part of the docs