### PR TITLE
feat: remove fragment paths from href

### DIFF
--- a/packages/expo-router/src/link/__tests__/href.test.node.ts
+++ b/packages/expo-router/src/link/__tests__/href.test.node.ts
@@ -7,6 +7,10 @@ describe(resolveHref, () => {
     expect(resolveHref("/foo/[...bar]")).toBe("/foo/[...bar]");
     expect(resolveHref("Tot4lly Wr0n9")).toBe("Tot4lly Wr0n9");
   });
+  it(`strips fragments`, () => {
+    expect(resolveHref("/(somn)/foobar")).toBe("/foobar");
+    expect(resolveHref("/(somn)/other/(remove)/foobar")).toBe("/other/foobar");
+  });
   it(`adds dynamic query parameters`, () => {
     expect(resolveHref({ pathname: "/[some]", query: { some: "value" } })).toBe(
       "/value"

--- a/packages/expo-router/src/link/href.ts
+++ b/packages/expo-router/src/link/href.ts
@@ -1,3 +1,5 @@
+import { matchFragmentName } from "../matchers";
+
 export type Href =
   | string
   | {
@@ -7,19 +9,27 @@ export type Href =
       query?: Record<string, any>;
     };
 
+/** Resolve an href object into a fully qualified, relative href. */
 export const resolveHref = (
   href: { pathname?: string; query?: Record<string, any> } | string
 ): string => {
   if (typeof href === "string") {
-    return href ?? "";
+    return resolveHref({ pathname: href ?? "" });
   }
-  const path = href.pathname ?? "";
+  const path = stripFragmentRoutes(href.pathname ?? "");
   if (!href?.query) {
     return path;
   }
   const { pathname, query } = createQualifiedPathname(path, { ...href.query });
   return pathname + (Object.keys(query).length ? `?${createQuery(query)}` : "");
 };
+
+function stripFragmentRoutes(pathname: string): string {
+  return pathname
+    .split("/")
+    .filter((segment) => matchFragmentName(segment) == null)
+    .join("/");
+}
 
 function createQualifiedPathname(pathname: string, query: Record<string, any>) {
   for (const [key, value = ""] of Object.entries(query)) {


### PR DESCRIPTION
- Automatically strip fragments from href paths: `/(foo)/bar` → `/bar`
