### PR TITLE
fix: fix relative href issue `../`

### DIFF
--- a/packages/expo-router/src/link/Link.tsx
+++ b/packages/expo-router/src/link/Link.tsx
@@ -18,7 +18,7 @@ type Props = {
   /** Forward props to child component. Useful for custom buttons. */
   asChild?: boolean;
 
-  /** Should replace the current screen without adding to the history. */
+  /** Should replace the current route without adding to the history. */
   replace?: boolean;
 
   onPress?: (
@@ -36,10 +36,11 @@ export function Redirect({ href }: { href: Href }) {
 }
 
 /**
- * Component to render link to another screen using a path.
+ * Component to render link to another route using a path.
  * Uses an anchor tag on the web.
  *
- * @param props.href Absolute path to screen (e.g. `/feeds/hot`).
+ * @param props.href Absolute path to route (e.g. `/feeds/hot`).
+ * @param props.replace Should replace the current route without adding to the history.
  * @param props.asChild Forward props to child component. Useful for custom buttons.
  * @param props.children Child elements to render the content.
  */

--- a/packages/expo-router/src/link/useLinkToPath.ts
+++ b/packages/expo-router/src/link/useLinkToPath.ts
@@ -4,8 +4,12 @@ import {
   NavigationContainerRefContext,
 } from "@react-navigation/core";
 import { LinkingContext } from "@react-navigation/native";
+import * as Linking from "expo-linking";
 import * as React from "react";
-import { Linking } from "react-native";
+
+function isRemoteHref(href: string): boolean {
+  return /:\/\//.test(href);
+}
 
 export function useLinkToPath() {
   const navigation = React.useContext(NavigationContainerRefContext);
@@ -13,22 +17,15 @@ export function useLinkToPath() {
 
   const linkTo = React.useCallback(
     (to: string, event?: string) => {
+      if (isRemoteHref(to)) {
+        Linking.openURL(to);
+        return;
+      }
+
       if (navigation === undefined) {
         throw new Error(
           "Couldn't find a navigation object. Is your component inside NavigationContainer?"
         );
-      }
-
-      if (!to.startsWith("/")) {
-        if (/:\/\//.test(to)) {
-          // Open external link
-          Linking.openURL(to);
-          return;
-        } else {
-          throw new Error(
-            `The href must start with '/' (${to}) or be a fully qualified URL.`
-          );
-        }
       }
 
       const { options } = linking;


### PR DESCRIPTION
- Remove check that forced URLs to start with `/`.
- Partially overlaps with https://github.com/expo/router/pull/58