### PR TITLE
feat: add href support to Tabs

### DIFF
--- a/apps/demo/app/(root)/(app).tsx
+++ b/apps/demo/app/(root)/(app).tsx
@@ -9,7 +9,7 @@ export default function AppLayout() {
       <Tabs.Screen
         name="index"
         options={{
-          tabBarButton: () => null,
+          href: null,
         }}
       />
       <Tabs.Screen
@@ -27,14 +27,12 @@ export default function AppLayout() {
       <Tabs.Screen
         name="[user]"
         options={{
-          // Force the button to go to the user's profile
-          tabBarButton: (props) => (
-            <Link
-              {...props}
-              style={[props.style, { display: "flex" }]}
-              href={`/${value.username}`}
-            />
-          ),
+          href: {
+            pathname: "/[user]",
+            query: {
+              user: value?.username,
+            },
+          },
           title: "User",
         }}
       />

--- a/apps/demo/app/(root)/(app).tsx
+++ b/apps/demo/app/(root)/(app).tsx
@@ -1,4 +1,4 @@
-import { Link, Tabs } from "expo-router";
+import { Tabs } from "expo-router";
 import { GoogleAuth } from "../../etc/auth/google";
 
 export default function AppLayout() {

--- a/apps/demo/app/(root)/(app)/[user]/index.tsx
+++ b/apps/demo/app/(root)/(app)/[user]/index.tsx
@@ -8,7 +8,9 @@ export default function App({ route }) {
   console.log("route", route);
   return (
     <View style={styles.container}>
-      <Text style={{ fontSize: 24 }}>Welcome @{route.params.user}</Text>
+      <Text style={{ fontSize: 24 }}>
+        Welcome @{route.params?.user || "ERR"}
+      </Text>
       <Text
         style={{ padding: 20, borderWidth: 2, borderColor: "black" }}
         onPress={() => signOut()}

--- a/apps/demo/app/(root)/(app)/[user]/index.tsx
+++ b/apps/demo/app/(root)/(app)/[user]/index.tsx
@@ -5,7 +5,6 @@ import { UrlBar } from "../../../../etc/urlBar";
 export { ErrorBoundary } from "expo-router";
 export default function App({ route }) {
   const signOut = GoogleAuth.useSignOut();
-  console.log("route", route);
   return (
     <View style={styles.container}>
       <Text style={{ fontSize: 24 }}>

--- a/apps/demo/app/(root)/(app)/[user]/status/[post].tsx
+++ b/apps/demo/app/(root)/(app)/[user]/status/[post].tsx
@@ -2,8 +2,8 @@ import { StyleSheet, Text, View } from "react-native";
 import { UrlBar } from "../../../../../etc/urlBar";
 
 export { ErrorBoundary } from "expo-router";
+
 export default function Post({ route }) {
-  console.log("route", route);
   return (
     <View style={styles.container}>
       <Text style={{ fontSize: 24 }}>

--- a/apps/demo/app/(root)/(app)/[user]/status/index.tsx
+++ b/apps/demo/app/(root)/(app)/[user]/status/index.tsx
@@ -1,0 +1,3 @@
+import { Unmatched } from "expo-router";
+
+export default Unmatched;

--- a/docs/docs/guides/tabs.md
+++ b/docs/docs/guides/tabs.md
@@ -1,0 +1,51 @@
+---
+title: Tabs
+---
+
+Expo Router adds an additional `href` screen option which can only be used with screen options that are an object (e.g. `screenOptions={{ href: "/path" }}`) and cannot be used simultaneously with `tabBarButton`.
+
+## Hiding a tab
+
+Sometimes you want a route to exist but not show up in the tab bar, you can pass `href: null` to disable the button:
+
+```js
+<Tabs.Screen
+  // Name of the route to hide.
+  name="index"
+  options={{
+    // This tab will no longer show up in the tab bar.
+    href: null,
+  }}
+/>
+```
+
+## Dynamic routes
+
+You may want to use a dynamic route in your tab bar (for example a profile tab). For this case, you'll want the button to always link to a specific href.
+
+```js
+import { Link, Tabs } from "expo-router";
+
+export default function AppLayout() {
+  return (
+    <Tabs>
+      <Tabs.Screen
+        // Name of the dynamic route.
+        name="[user]"
+        options={{
+          // Ensure the tab always links to the same href.
+          href: "/evanbacon",
+
+          // OR you can use the Href object:
+          href: {
+            pathname: "/[user]",
+            query: {
+              user: "evanbacon",
+            },
+          },
+        }}
+      />
+    </Tabs>
+  );
+}
+```

--- a/packages/expo-router/src/layouts/Tabs.tsx
+++ b/packages/expo-router/src/layouts/Tabs.tsx
@@ -1,16 +1,63 @@
+import { Pressable } from "@bacons/react-views";
 import {
   BottomTabNavigationOptions,
   createBottomTabNavigator,
 } from "@react-navigation/bottom-tabs";
+import React from "react";
+import { Platform } from "react-native";
 
+import { Link } from "../link/Link";
+import { Href } from "../link/href";
 import { withLayoutContext } from "./withLayoutContext";
 
 // This is the only way to access the navigator.
 const BottomTabNavigator = createBottomTabNavigator().Navigator;
 
 export const Tabs = withLayoutContext<
-  BottomTabNavigationOptions,
+  BottomTabNavigationOptions & { href?: Href | null },
   typeof BottomTabNavigator
->(BottomTabNavigator);
+>(BottomTabNavigator, (screens) => {
+  // Support the `href` shortcut prop.
+  return screens.map((screen) => {
+    if (
+      typeof screen.options !== "function" &&
+      screen.options?.href !== undefined
+    ) {
+      const { href, ...options } = screen.options;
+      if (options.tabBarButton) {
+        throw new Error("Cannot use `href` and `tabBarButton` together.");
+      }
+      return {
+        ...screen,
+        options: {
+          ...options,
+          // Force the button to go to the user's profile
+          tabBarButton: (props) => {
+            if (href == null) {
+              return null;
+            }
+            const children =
+              Platform.OS === "web" ? (
+                props.children
+              ) : (
+                <Pressable>{props.children}</Pressable>
+              );
+            return (
+              <Link
+                {...props}
+                style={[{ display: "flex" }, props.style]}
+                // @ts-expect-error
+                href={href}
+                asChild={Platform.OS !== "web"}
+                children={children}
+              />
+            );
+          },
+        },
+      };
+    }
+    return screen;
+  });
+});
 
 export default Tabs;

--- a/packages/expo-router/src/layouts/withLayoutContext.tsx
+++ b/packages/expo-router/src/layouts/withLayoutContext.tsx
@@ -62,7 +62,8 @@ export function withLayoutContext<
   TOptions extends object,
   T extends React.ComponentType<any>
 >(
-  Nav: T
+  Nav: T,
+  processor?: (options: ScreenProps<TOptions>[]) => ScreenProps<TOptions>[]
 ): React.ForwardRefExoticComponent<
   React.PropsWithoutRef<PickPartial<React.ComponentProps<T>, "children">> &
     React.RefAttributes<unknown>
@@ -79,7 +80,9 @@ export function withLayoutContext<
     ) => {
       const { screens } = useFilterScreenChildren(userDefinedChildren);
 
-      const sorted = useSortedScreens(screens ?? []);
+      const processed = processor ? processor(screens ?? []) : screens;
+
+      const sorted = useSortedScreens(processed ?? []);
 
       // Prevent throwing an error when there are no screens.
       if (!sorted.length) {


### PR DESCRIPTION
- resolve ENG-6321
- add ability to directly link to a dynamic route from a tab bar (easily).
- add ability to prevent a tab bar item from showing.

The solution here could be improved a lot, but this seems fine for now. Devs should be able to easily create a tab bar like the ones found in Twitter and Instagram where the profile button links to `/[user]`.