### PR TITLE
feat!: query -> params

### DIFF
--- a/docs/docs/features/linking.md
+++ b/docs/docs/features/linking.md
@@ -46,9 +46,9 @@ Prefer the `useLink` hook to `useNavigation` from React Navigation as `useLink` 
 
 ## `useLink` API
 
-- **push**: _`(href: Href) => void`_ Navigate to a route. You can provide a full path like `/profile/settings` or a relative path like `../settings`. Navigate to dynamic routes by passing an object like `{ pathname: 'profile', query: { id: '123' } }`.
+- **push**: _`(href: Href) => void`_ Navigate to a route. You can provide a full path like `/profile/settings` or a relative path like `../settings`. Navigate to dynamic routes by passing an object like `{ pathname: 'profile', params: { id: '123' } }`.
 - **replace**: _`(href: Href) => void`_ Same API as `push` but replaces the current route in the history instead of pushing a new one. This is useful for redirects.
-- **back**: _`() => void`_ Navigate to a route. You can provide a full path like `/profile/settings` or a relative path like `../settings`. Navigate to dynamic routes by passing an object like `{ pathname: 'profile', query: { id: '123' } }`.
+- **back**: _`() => void`_ Navigate to a route. You can provide a full path like `/profile/settings` or a relative path like `../settings`. Navigate to dynamic routes by passing an object like `{ pathname: 'profile', params: { id: '123' } }`.
 
 > This API is similar to Next.js's `useRouter` hook, but adjusted to work around the state management requirements of native.
 
@@ -57,7 +57,7 @@ Prefer the `useLink` hook to `useNavigation` from React Navigation as `useLink` 
 The `Href` type is a union of the following types:
 
 - **string**: A full path like `/profile/settings` or a relative path like `../settings`.
-- **object**: An object with a `pathname` and optional `query` object. The `pathname` can be a full path like `/profile/settings` or a relative path like `../settings`. The `query` can be an object of key/value pairs.
+- **object**: An object with a `pathname` and optional `params` object. The `pathname` can be a full path like `/profile/settings` or a relative path like `../settings`. The `params` can be an object of key/value pairs.
 
 ## `useHref` API
 
@@ -65,7 +65,7 @@ The `useHref` hook provides the current location information for a route.
 
 - **href**: _`string`_ The relative normalized path that would show up in the URL bar.
 - **pathname**: _`string`_ The relative template path reflecting the current route. e.g. `/profile/[id]`.
-- **query**: _`Record<string, any>`_ Query parameters for the current route. e.g. `{ id: '123' }`.
+- **params**: _`Record<string, any>`_ Query parameters for the current route. e.g. `{ id: '123' }`.
 
 Given a route at `app/profile/[id].tsx` if the hook is called while the URL is `/profile/123`, the results of `useHref` would be as follows:
 
@@ -73,7 +73,7 @@ Given a route at `app/profile/[id].tsx` if the hook is called while the URL is `
 {
   href: "/profile/123",
   pathname: "/profile/[id]",
-  query: { id: "123" },
+  params: { id: "123" },
 }
 ```
 

--- a/docs/docs/guides/tabs.md
+++ b/docs/docs/guides/tabs.md
@@ -39,7 +39,7 @@ export default function AppLayout() {
           // OR you can use the Href object:
           href: {
             pathname: "/[user]",
-            query: {
+            params: {
               user: "evanbacon",
             },
           },

--- a/packages/expo-router/src/link/__tests__/href.test.node.ts
+++ b/packages/expo-router/src/link/__tests__/href.test.node.ts
@@ -12,42 +12,42 @@ describe(resolveHref, () => {
     expect(resolveHref("/(somn)/other/(remove)/foobar")).toBe("/other/foobar");
   });
   it(`adds dynamic query parameters`, () => {
-    expect(resolveHref({ pathname: "/[some]", query: { some: "value" } })).toBe(
-      "/value"
-    );
+    expect(
+      resolveHref({ pathname: "/[some]", params: { some: "value" } })
+    ).toBe("/value");
     expect(
       resolveHref({
         pathname: "/[some]/cool/[thing]",
-        query: { some: "value" },
+        params: { some: "value" },
       })
     ).toBe("/value/cool/[thing]");
     expect(
       resolveHref({
         pathname: "/[some]/cool/[thing]",
-        query: { some: "alpha", thing: "beta" },
+        params: { some: "alpha", thing: "beta" },
       })
     ).toBe("/alpha/cool/beta");
   });
   it(`adds query parameters`, () => {
-    expect(resolveHref({ pathname: "/alpha", query: { beta: "value" } })).toBe(
+    expect(resolveHref({ pathname: "/alpha", params: { beta: "value" } })).toBe(
       "/alpha?beta=value"
     );
     expect(
       resolveHref({
         pathname: "/alpha",
-        query: { beta: "value", gamma: "another" },
+        params: { beta: "value", gamma: "another" },
       })
     ).toBe("/alpha?beta=value&gamma=another");
     expect(
       resolveHref({
         pathname: "/alpha",
-        query: {},
+        params: {},
       })
     ).toBe("/alpha");
     expect(
       resolveHref({
         pathname: "/alpha/[beta]",
-        query: { beta: "some", gamma: "another" },
+        params: { beta: "some", gamma: "another" },
       })
     ).toBe("/alpha/some?gamma=another");
   });

--- a/packages/expo-router/src/link/href.ts
+++ b/packages/expo-router/src/link/href.ts
@@ -17,10 +17,12 @@ export const resolveHref = (href: Href): string => {
     return resolveHref({ pathname: href ?? "" });
   }
   const path = stripFragmentRoutes(href.pathname ?? "");
-  if (!href?.query) {
+  if (!href?.params) {
     return path;
   }
-  const { pathname, params } = createQualifiedPathname(path, { ...href.query });
+  const { pathname, params } = createQualifiedPathname(path, {
+    ...href.params,
+  });
   return (
     pathname +
     (Object.keys(params).length ? `?${createQueryParams(params)}` : "")

--- a/packages/expo-router/src/link/href.ts
+++ b/packages/expo-router/src/link/href.ts
@@ -1,18 +1,18 @@
 import { matchFragmentName } from "../matchers";
 
-export type Href =
-  | string
-  | {
-      /** Path representing the selected route `/[id]` */
-      pathname?: string;
-      /** Query parameters for the path. */
-      query?: Record<string, any>;
-    };
+export type Href = string | HrefObject;
+
+export type HrefObject = {
+  /** Path representing the selected route `/[id]`. */
+  pathname?: string;
+  /** Query parameters for the path. */
+  params?: Record<string, any>;
+  /** @deprecated use `params` instead. */
+  query?: Record<string, any>;
+};
 
 /** Resolve an href object into a fully qualified, relative href. */
-export const resolveHref = (
-  href: { pathname?: string; query?: Record<string, any> } | string
-): string => {
+export const resolveHref = (href: Href): string => {
   if (typeof href === "string") {
     return resolveHref({ pathname: href ?? "" });
   }
@@ -20,8 +20,11 @@ export const resolveHref = (
   if (!href?.query) {
     return path;
   }
-  const { pathname, query } = createQualifiedPathname(path, { ...href.query });
-  return pathname + (Object.keys(query).length ? `?${createQuery(query)}` : "");
+  const { pathname, params } = createQualifiedPathname(path, { ...href.query });
+  return (
+    pathname +
+    (Object.keys(params).length ? `?${createQueryParams(params)}` : "")
+  );
 };
 
 function stripFragmentRoutes(pathname: string): string {
@@ -31,8 +34,11 @@ function stripFragmentRoutes(pathname: string): string {
     .join("/");
 }
 
-function createQualifiedPathname(pathname: string, query: Record<string, any>) {
-  for (const [key, value = ""] of Object.entries(query)) {
+function createQualifiedPathname(
+  pathname: string,
+  params: Record<string, any>
+): Omit<Required<HrefObject>, "query"> {
+  for (const [key, value = ""] of Object.entries(params)) {
     const dynamicKey = `[${key}]`;
     const deepDynamicKey = `[...${key}]`;
     if (pathname.includes(dynamicKey)) {
@@ -49,13 +55,13 @@ function createQualifiedPathname(pathname: string, query: Record<string, any>) {
       continue;
     }
 
-    delete query[key];
+    delete params[key];
   }
-  return { pathname, query };
+  return { pathname, params };
 }
 
-function createQuery(query: Record<string, any>) {
-  return Object.keys(query)
-    .map((key) => `${key}=${query[key]}`)
+function createQueryParams(params: Record<string, any>) {
+  return Object.keys(params)
+    .map((key) => `${key}=${params[key]}`)
     .join("&");
 }

--- a/packages/expo-router/src/link/useHref.ts
+++ b/packages/expo-router/src/link/useHref.ts
@@ -3,12 +3,9 @@ import React from "react";
 
 import { RootContainer } from "../ContextNavigationContainer";
 import getPathFromState, { State } from "../fork/getPathFromState";
+import { HrefObject } from "./href";
 
-type RouteInfo = {
-  /** Path representing the selected route `/[id]` */
-  pathname: string;
-  /** Query parameters for the path. */
-  query: Record<string, any>;
+type RouteInfo = Omit<Required<HrefObject>, "query"> & {
   /** Normalized path representing the selected route `/[id]?id=normal` -> `/normal` */
   href: string;
 };
@@ -21,7 +18,7 @@ function getRouteInfoFromState(
     return {
       href: "",
       pathname: "",
-      query: {},
+      params: {},
     };
   }
 
@@ -55,7 +52,7 @@ function compareRouteInfo(a: RouteInfo, b: RouteInfo) {
   return (
     a.href === b.href &&
     a.pathname === b.pathname &&
-    compareShallowRecords(a.query, b.query)
+    compareShallowRecords(a.params, b.params)
   );
 }
 
@@ -132,7 +129,7 @@ function getNormalizedStatePath(statePath: string) {
     pathname: components[0],
     // TODO: This is not efficient, we should generate based on the state instead
     // of converting to string then back to object
-    query: parseQueryString(components[1] ?? ""),
+    params: parseQueryString(components[1] ?? ""),
   };
 }
 
@@ -140,11 +137,11 @@ function parseQueryString(val: string) {
   if (!val) {
     return {};
   }
-  const query = {};
+  const params = {};
   const a = val.split("&");
   for (let i = 0; i < a.length; i++) {
     const b = a[i].split("=");
-    query[decodeURIComponent(b[0])] = decodeURIComponent(b[1] || "");
+    params[decodeURIComponent(b[0])] = decodeURIComponent(b[1] || "");
   }
-  return query;
+  return params;
 }


### PR DESCRIPTION
- `params` is used in React Navigation and Ruby on Rails. Mark `query` as deprecated.
- resolve https://github.com/expo/router/issues/92
- open to flipping this naming and marking `params` as deprecated instead.