### PR TITLE
docs: update reference from __index to _sitemap on linking page

### DIFF
--- a/docs/docs/features/linking.md
+++ b/docs/docs/features/linking.md
@@ -160,6 +160,6 @@ You can also search for links directly in a browser like Safari or Chrome to tes
 
 ![](/img/directory.png)
 
-We currently inject a `/__index` file which provides a list of all routes in the app. This is useful for debugging and development. This screen is only injected during development, and won't be available in production.
+We currently inject a `/_sitemap` file which provides a list of all routes in the app. This is useful for debugging and development. This screen is only injected during development, and won't be available in production.
 
 We may remove this feature for the official release, but it's useful for now.


### PR DESCRIPTION
updating docs on linking page to reference _sitemap instead of __index