### PR TITLE
fix: use href state as soon as possible

### DIFF
--- a/packages/expo-router/src/link/useHref.ts
+++ b/packages/expo-router/src/link/useHref.ts
@@ -61,7 +61,7 @@ export function useHref(): RouteInfo {
 
   const navigation = RootContainer.getRef();
   const [routeInfo, setRouteInfo] = React.useState<RouteInfo>(
-    getRouteInfoFromState(getPathFromState, null)
+    getRouteInfoFromState(getPathFromState, navigation?.getRootState())
   );
 
   const maybeUpdateRouteInfo = React.useCallback(


### PR DESCRIPTION
# Motivation

Fix data loading issues by attempting to return the value from `useHref` on the first render.

