### PR TITLE
feat: add support for file names with spaces

### DIFF
--- a/packages/expo-router/src/fork/__tests__/getStateFromPath.test.node.ts
+++ b/packages/expo-router/src/fork/__tests__/getStateFromPath.test.node.ts
@@ -1,5 +1,22 @@
 import getStateFromPath from "../getStateFromPath";
 
+it(`supports spaces`, () => {
+  expect(
+    getStateFromPath("/hello%20world", {
+      screens: {
+        "hello world": "hello world",
+      },
+    } as any)
+  ).toEqual({
+    routes: [
+      {
+        name: "hello world",
+        path: "/hello%20world",
+      },
+    ],
+  });
+});
+
 it(`adds dynamic route params from all levels of the path`, () => {
   // A route at `app/[foo]/bar/[baz]/other` should get all of the params from the path.
   expect(

--- a/packages/expo-router/src/fork/getStateFromPath.ts
+++ b/packages/expo-router/src/fork/getStateFromPath.ts
@@ -513,6 +513,9 @@ const createConfigItem = (
               return `(([^/]+\\/)${it.endsWith("?") ? "?" : ""})`;
             }
 
+            // Allow spaces in file path names.
+            it = it.replace(" ", "%20");
+
             return `${it === "*" ? ".*" : escape(it)}\\/`;
           })
           .join("")})`


### PR DESCRIPTION
# Motivation

- Support file paths that have spaces

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# Execution

- Add support to `getStateFromPath` which encodes spaces to `%20`

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

- Added unit tests