### PR TITLE
feat: add support for matching index paths

### DIFF
--- a/packages/expo-router/src/fork/__tests__/getStateFromPath.test.node.ts
+++ b/packages/expo-router/src/fork/__tests__/getStateFromPath.test.node.ts
@@ -1,5 +1,89 @@
 import getStateFromPath from "../getStateFromPath";
 
+describe("index paths", () => {
+  it(`matches index paths against empty screens`, () => {
+    expect(
+      getStateFromPath("/", {
+        screens: {
+          index: "",
+          other: "other",
+        },
+      } as any)
+    ).toEqual({
+      routes: [
+        {
+          name: "index",
+          path: "/",
+        },
+      ],
+    });
+  });
+  it(`matches index paths against /index`, () => {
+    expect(
+      getStateFromPath("/index", {
+        screens: {
+          index: "",
+          other: "other",
+        },
+      } as any)
+    ).toEqual({
+      routes: [
+        {
+          name: "index",
+          path: "/index",
+        },
+      ],
+    });
+  });
+  it(`matches index paths against nested /index`, () => {
+    const config = {
+      screens: {
+        index: "",
+        other: "other",
+        nested: {
+          path: "nested",
+          screens: {
+            index: "",
+          },
+        },
+      },
+    } as any;
+    expect(getStateFromPath("/nested/index", config)).toEqual({
+      routes: [
+        {
+          name: "nested",
+          state: { routes: [{ name: "index", path: "/nested/index" }] },
+        },
+      ],
+    });
+    expect(getStateFromPath("/nested/", config)).toEqual({
+      routes: [
+        {
+          name: "nested",
+          state: { routes: [{ name: "index", path: "/nested/" }] },
+        },
+      ],
+    });
+  });
+});
+
+it(`supports spaces`, () => {
+  expect(
+    getStateFromPath("/hello%20world", {
+      screens: {
+        "hello world": "hello world",
+      },
+    } as any)
+  ).toEqual({
+    routes: [
+      {
+        name: "hello world",
+        path: "/hello%20world",
+      },
+    ],
+  });
+});
+
 it(`adds dynamic route params from all levels of the path`, () => {
   // A route at `app/[foo]/bar/[baz]/other` should get all of the params from the path.
   expect(


### PR DESCRIPTION
# Motivation

- Projects should be able to match `/index` and `/` against a file named `index.tsx`.
- Resolve https://github.com/expo/router/issues/81 (release blocking)

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# Execution

- Add support for matching in `getStateFromPath`

# Test Plan

- [ ] Test a file `(fragment).tsx` asserts a conflict with `index.tsx`

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
