### PR TITLE
fix: prevent eagerly loading routes by options

### DIFF
--- a/packages/expo-router/src/useScreens.tsx
+++ b/packages/expo-router/src/useScreens.tsx
@@ -166,7 +166,10 @@ function routeToScreen(
       name={route.route}
       key={route.route}
       options={(args) => {
-        const staticOptions = route.getExtras()?.getNavOptions;
+        // Only eager load generated components
+        const staticOptions = route.generated
+          ? route.getExtras()?.getNavOptions
+          : null;
         const staticResult =
           typeof staticOptions === "function"
             ? staticOptions(args)


### PR DESCRIPTION
# Motivation

- Required for https://github.com/expo/router/issues/84
- Routes need to be fully self-contained in order to split them and load separately.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# Execution

- Only eagerly load the Sitemap and other generated screens.

<!--
How did you build this feature or fix this bug and why?
-->
