### PR TITLE
feat: add a demo for web's modal(PoC)

### DIFF
--- a/apps/demo-web-modal/.gitignore
+++ b/apps/demo-web-modal/.gitignore
@@ -1,0 +1,64 @@
+# OSX
+#
+.DS_Store
+
+# Xcode
+#
+build/
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+xcuserdata
+*.xccheckout
+*.moved-aside
+DerivedData
+*.hmap
+*.ipa
+*.xcuserstate
+project.xcworkspace
+
+# Android/IntelliJ
+#
+build/
+.idea
+.gradle
+local.properties
+*.iml
+*.hprof
+
+# node.js
+#
+node_modules/
+npm-debug.log
+yarn-error.log
+
+# BUCK
+buck-out/
+\.buckd/
+*.keystore
+
+# fastlane
+#
+# It is recommended to not store the screenshots in the git repo. Instead, use fastlane to re-generate the
+# screenshots whenever they are needed.
+# For more information about the recommended setup visit:
+# https://docs.fastlane.tools/best-practices/source-control/
+
+*/fastlane/report.xml
+*/fastlane/Preview.html
+*/fastlane/screenshots
+
+# Bundle artifacts
+*.jsbundle
+
+# CocoaPods
+/ios/Pods/
+
+# Expo
+.expo/*
+web-build/

--- a/apps/demo-web-modal/README.md
+++ b/apps/demo-web-modal/README.md
@@ -1,0 +1,15 @@
+# Expo Router Example
+
+Use [`expo-router`](https://expo.github.io/router) to build native navigation using files in the `app/` directory.
+
+## 🚀 How to use
+
+```sh
+npx create-react-native-app -t with-router
+```
+
+## 📝 Notes
+
+- [Expo Router: Docs](https://expo.github.io/router)
+- [Expo Router: Repo](https://github.com/expo/router)
+- [Request for Comments](https://github.com/expo/router/discussions/1)

--- a/apps/demo-web-modal/app.json
+++ b/apps/demo-web-modal/app.json
@@ -1,0 +1,6 @@
+{
+  "expo": {
+    "scheme": "acme",
+    "web": { "bundler": "metro" }
+  }
+}

--- a/apps/demo-web-modal/app/_layout.jsx
+++ b/apps/demo-web-modal/app/_layout.jsx
@@ -1,0 +1,61 @@
+import { View } from "react-native";
+import { Layout, Link, Children, useHref } from "expo-router";
+
+import { TabRouter } from "@react-navigation/native";
+
+export default function Page() {
+  const { pathname } = useHref();
+
+  // When the given query is 404 show site map by simply rendering <Children />
+  return !pathname.includes("[...404]") ? (
+    <Layout router={TabRouter}>
+      <Children />
+      <View
+        style={{
+          flex: 1,
+          justifyContent: "center",
+          alignItems: "center",
+          backgroundColor: "blue",
+        }}
+      >
+        <Link href="/post/12321" style={{ color: "white" }}>
+          Open modal
+        </Link>
+      </View>
+      <View
+        style={{
+          flex: 1,
+          justifyContent: "center",
+          alignItems: "center",
+          backgroundColor: "green",
+        }}
+      >
+        <Link href="/post/12321">Open modal</Link>
+      </View>
+      <View
+        style={{
+          flex: 1,
+          justifyContent: "center",
+          alignItems: "center",
+          backgroundColor: "yellow",
+        }}
+      >
+        <Link href="/post/12321">Open modal</Link>
+      </View>
+      <View
+        style={{
+          flex: 1,
+          justifyContent: "center",
+          alignItems: "center",
+          backgroundColor: "black",
+        }}
+      >
+        <Link href="/post/12321" style={{ color: "white" }}>
+          Open modal
+        </Link>
+      </View>
+    </Layout>
+  ) : (
+    <Children />
+  );
+}

--- a/apps/demo-web-modal/app/index.jsx
+++ b/apps/demo-web-modal/app/index.jsx
@@ -1,0 +1,5 @@
+// this component is deliberatively empty to set UI elements under the modal
+// you can find them in _layout.js
+export default function Home() {
+  return <></>;
+}

--- a/apps/demo-web-modal/app/post/[id].jsx
+++ b/apps/demo-web-modal/app/post/[id].jsx
@@ -1,0 +1,32 @@
+import { View, Text, TouchableOpacity } from "react-native";
+
+/** modal */
+export default function Page({ navigation, route }) {
+  return (
+    <TouchableOpacity
+      style={{
+        position: "absolute",
+        width: "100%",
+        height: "100%",
+        backgroundColor: "rgba(0,0,0,0.4)",
+        justifyContent: "center",
+        alignItems: "center",
+        zIndex: 9999,
+      }}
+      onPress={() => navigation.goBack()}
+    >
+      <View
+        style={{
+          width: 300,
+          height: 600,
+          backgroundColor: "white",
+          justifyContent: "center",
+          alignItems: "center",
+        }}
+      >
+        <Text>given id:</Text>
+        <Text>{route.params.id}</Text>
+      </View>
+    </TouchableOpacity>
+  );
+}

--- a/apps/demo-web-modal/babel.config.js
+++ b/apps/demo-web-modal/babel.config.js
@@ -1,0 +1,10 @@
+module.exports = function (api) {
+  api.cache(true);
+  return {
+    presets: ["babel-preset-expo"],
+    plugins: [
+      "react-native-reanimated/plugin",
+      require.resolve("expo-router/babel"),
+    ],
+  };
+};

--- a/apps/demo-web-modal/index.js
+++ b/apps/demo-web-modal/index.js
@@ -1,0 +1,2 @@
+import "@bacons/expo-metro-runtime";
+import "expo-router/entry";

--- a/apps/demo-web-modal/package.json
+++ b/apps/demo-web-modal/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "demo-web-modal",
+  "version": "1.0.0",
+  "main": "index",
+  "scripts": {
+    "start": "expo start",
+    "android": "expo start --android",
+    "ios": "expo start --ios",
+    "web": "expo start --web"
+  },
+  "dependencies": {
+    "@react-native-async-storage/async-storage": "~1.17.3",
+    "expo": "^46.0.13",
+    "expo-auth-session": "~3.7.1",
+    "expo-random": "~12.3.0",
+    "expo-router": "*",
+    "expo-secure-store": "~11.3.0",
+    "react": "18.0.0",
+    "react-dom": "18.0.0",
+    "react-native": "0.69.6",
+    "react-native-web": "~0.18.7",
+    "typescript": "^4.6.3",
+    "react-native-safe-area-context": "4.3.1",
+    "react-native-screens": "~3.15.0",
+    "react-native-gesture-handler": "~2.5.0",
+    "react-native-reanimated": "~2.9.1",
+    "@react-navigation/drawer": "^6.4.4"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.12.9",
+    "@types/react": "~18.0.0",
+    "@types/react-native": "~0.69.1",
+    "@welldone-software/why-did-you-render": "^7.0.1",
+    "babel-plugin-transform-imports": "^2.0.0"
+  },
+  "private": true
+}


### PR DESCRIPTION
# Motivation

I was trying to implement a modal mentioned in https://github.com/expo/router/issues/83. Before start writing the documentation page for it, I wanted to get some feedback from someone to make sure the implementation follows the dependency's best practice.

# Execution

<!--
How did you build this feature or fix this bug and why?
-->
The drawing below is the rough chart of its implementation. The reason why I ended up having UI elements in `_layout.jsx` instead of `index.jsx` was that it couldn't persist on the screen otherwise. It could've been more elegant if I could use `<outlet />` in the route like [remix's example](https://codesandbox.io/s/2pil5). However, I'm also not sure this is the best practice for the usecase. I'd appreciate feedback on it!

![Screen Shot 2022-10-22 at 6 32 47 PM](https://user-images.githubusercontent.com/44686790/197368907-d8a6e757-f380-4ebb-97cf-12898a82c6e2.png)


# Test Plan

1. go to `apps/demo-web-modal` and run yarn
2. run the app and you should be able to playaround with it

![2022-10-22 18 23 26](https://user-images.githubusercontent.com/44686790/197369023-522ebd03-eeca-436b-9a97-26d9869ff5f1.gif)

