### PR TITLE
feat: support expo sdk 47 while maintaining support for sdk 46

### DIFF
--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -52,7 +52,7 @@ npx expo install expo-router
 Install peer dependencies:
 
 ```
-npx expo install react-native-safe-area-context react-native-screens
+npx expo install react-native-safe-area-context react-native-screens expo-linking expo-constants expo-status-bar
 ```
 
 Then delete the entry point in your `package.json`, or replace it with `index.js` to be explicit:

--- a/packages/expo-router/package.json
+++ b/packages/expo-router/package.json
@@ -61,15 +61,16 @@
   },
   "devDependencies": {
     "@radix-ui/react-slot": "^1.0.0",
+    "@react-navigation/drawer": "^6.4.4",
     "@types/jest": "^26",
     "expo-module-scripts": "^2.0.0",
     "expo-splash-screen": "^0.16.2",
+    "expo-status-bar": "^1.4.0",
     "jest": "^26.6.3",
-    "react-native-safe-area-context": "4.3.1",
-    "react-native-screens": "~3.15.0",
     "react-native-gesture-handler": "~2.5.0",
     "react-native-reanimated": "~2.9.1",
-    "@react-navigation/drawer": "^6.4.4"
+    "react-native-safe-area-context": "4.3.1",
+    "react-native-screens": "~3.15.0"
   },
   "dependencies": {
     "@bacons/expo-metro-runtime": "^2.0.1",

--- a/packages/expo-router/package.json
+++ b/packages/expo-router/package.json
@@ -36,14 +36,17 @@
     "preset": "jest-expo"
   },
   "peerDependencies": {
-    "expo": "^46.0.2",
-    "expo-splash-screen": "^0.16.2",
-    "metro": "~0.73.1",
-    "react-native-gesture-handler": "~2.5.0",
-    "react-native-reanimated": "~2.9.1",
     "@react-navigation/drawer": "^6.4.4",
-    "react-native-safe-area-context": "4.3.1",
-    "react-native-screens": "~3.15.0"
+    "expo": "~46.0.2 || ~47.0.0-beta || ~47.0.0",
+    "expo-constants": "*",
+    "expo-linking": "*",
+    "expo-splash-screen": "*",
+    "expo-status-bar": "*",
+    "metro": "~0.73.1",
+    "react-native-gesture-handler": "*",
+    "react-native-reanimated": "*",
+    "react-native-safe-area-context": "*",
+    "react-native-screens": "*"
   },
   "peerDependenciesMeta": {
     "react-native-gesture-handler": {
@@ -74,10 +77,6 @@
     "@radix-ui/react-slot": "^1.0.0",
     "@react-navigation/bottom-tabs": "^6.3.3",
     "@react-navigation/native": "^6.0.12",
-    "@react-navigation/native-stack": "^6.8.0",
-    "expo-constants": "~13.2.4",
-    "expo-linking": "^3.2.2",
-    "expo-splash-screen": "^0.16.2",
-    "expo-status-bar": "^1.4.0"
+    "@react-navigation/native-stack": "^6.8.0"
   }
 }

--- a/packages/expo-router/package.json
+++ b/packages/expo-router/package.json
@@ -57,6 +57,9 @@
     },
     "@react-navigation/drawer": {
       "optional": true
+    },
+    "expo-splash-screen": {
+      "optional": true
     }
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7553,7 +7553,7 @@ expo-keep-awake@~10.2.0:
   resolved "https://registry.yarnpkg.com/expo-keep-awake/-/expo-keep-awake-10.2.0.tgz#46f04740bccd321732bbbed93491e2076d5dbbd7"
   integrity sha512-kIRtO4Hmrvxh4E45IPWG/NiUZsuRe1AQwBT09pq+kx8nm6tUS4B9TeL6+1NFy+qVBLbGKDqoQD5Ez7XYTFtBeQ==
 
-expo-linking@^3.2.2, expo-linking@~3.2.0:
+expo-linking@~3.2.0:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/expo-linking/-/expo-linking-3.2.2.tgz#88272cc6d4aab9804d7a1f6c2521cae00b1477a2"
   integrity sha512-2OY7WAyZXuc8zdTGm2rLu5ESJaFL2TYmPHsJuDJcfIJFaw+nS5vIVk5DGPlk+zCNC3uoqT02t7a5PZVp2bvqtQ==


### PR DESCRIPTION
# Motivation

The current version of expo-router is incompatible with SDK 47 because it has hard dependencies and also peer dependencies (npm 7+ auto install) on SDK 46 versions of various packages.

# Execution

Where possible, move everything to `*` dependency. These versions will already largely be enforced by the Expo package validation. This isn't the best solution and we could certainly specify tighter ranges if we find a need to anywhere.

# Test Plan

Use the library in SDK 47 with npm 7
