### PR TITLE
fix: import SafeAreaView from react-native-safe-area-context in tutorial

### DIFF
--- a/packages/expo-router/src/onboard/Tutorial.tsx
+++ b/packages/expo-router/src/onboard/Tutorial.tsx
@@ -1,6 +1,7 @@
 import { View, Text, Pressable, StyleSheet } from "@bacons/react-views";
 import React from "react";
-import { SafeAreaView, StatusBar, Platform } from "react-native";
+import { StatusBar, Platform } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
 
 import { createEntryFileAsync } from "./createEntryFile";
 


### PR DESCRIPTION
# Motivation

![IMG_4329](https://user-images.githubusercontent.com/90494/198909988-80fbd983-1afc-4aa1-aea7-e210c55ac883.png)

I encountered this when loading a new expo-router app in SDK 47, as did @kbrandwijk. It's not immediately clear to me why this is the case, and it may be pointing to a regression in React Native core, but since we depend on react-native-safe-area-context we might as well use the SafeAreaView from that library here instead. That solves the issue on my end.

# Execution

Replace SafeAreaView from react-native with the react-native-safe-area-context equivalent.

# Test Plan

Modify node_modules directly in an SDK 47 project to confirm.