### PR TITLE
feat: support unstable initialRouteName

### DIFF
--- a/apps/demo/app_initialRouteName/(app)/_layout.tsx
+++ b/apps/demo/app_initialRouteName/(app)/_layout.tsx
@@ -1,0 +1,9 @@
+import { Stack } from "expo-router";
+
+export const unstable_settings = {
+  initialRouteName: "index",
+};
+
+export default function Layout() {
+  return <Stack />;
+}

--- a/apps/demo/app_initialRouteName/(app)/index.tsx
+++ b/apps/demo/app_initialRouteName/(app)/index.tsx
@@ -1,0 +1,37 @@
+import { Link } from "expo-router";
+import { StyleSheet, Text, View } from "react-native";
+
+export default function Page() {
+  return (
+    <View style={styles.container}>
+      <View style={styles.main}>
+        <Text style={styles.title}>Hello World</Text>
+        <Link href="/other" style={styles.subtitle}>
+          This is the first page of your app.
+        </Link>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: "center",
+    padding: 24,
+  },
+  main: {
+    flex: 1,
+    justifyContent: "center",
+    maxWidth: 960,
+    marginHorizontal: "auto",
+  },
+  title: {
+    fontSize: 64,
+    fontWeight: "bold",
+  },
+  subtitle: {
+    fontSize: 36,
+    color: "#38434D",
+  },
+});

--- a/apps/demo/app_initialRouteName/(app)/other.tsx
+++ b/apps/demo/app_initialRouteName/(app)/other.tsx
@@ -1,0 +1,33 @@
+import { StyleSheet, Text, View } from "react-native";
+
+export default function Page() {
+  return (
+    <View style={styles.container}>
+      <View style={styles.main}>
+        <Text style={styles.title}>Other</Text>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: "center",
+    padding: 24,
+  },
+  main: {
+    flex: 1,
+    justifyContent: "center",
+    maxWidth: 960,
+    marginHorizontal: "auto",
+  },
+  title: {
+    fontSize: 64,
+    fontWeight: "bold",
+  },
+  subtitle: {
+    fontSize: 36,
+    color: "#38434D",
+  },
+});

--- a/docs/docs/features/layout-routes.md
+++ b/docs/docs/features/layout-routes.md
@@ -100,3 +100,32 @@ The Fragment convention is similar to:
 - [Route Groups](https://nextjs.org/blog/layouts-rfc#route-groups) in the upcoming Next.js layouts RFC (`(group)`).
 
 </details>
+
+## Unstable Settings
+
+> This feature will be replaced with something that supports React Suspense in the future.
+
+To support defining the `initialRouteName` you can use the `unstable_settings` object export from any Layout Route.
+
+```bash title="File System"
+app/
+  (app)/
+    _layout.js
+    index.js
+    other.js
+```
+
+```js title=app/(app)/_layout.tsx
+import { Stack } from "expo-router";
+
+export const unstable_settings = {
+  // Ensure any route can link back to `/`
+  initialRouteName: "index",
+};
+
+export default function Layout() {
+  return <Stack />;
+}
+```
+
+Now deep linking directly to `/other` or reloading the page will continue to show the back arrow.

--- a/packages/expo-router/src/Route.tsx
+++ b/packages/expo-router/src/Route.tsx
@@ -8,6 +8,8 @@ export type PickPartial<T, K extends keyof T> = Omit<T, K> &
   Partial<Pick<T, K>>;
 
 export type RouteNode = {
+  /** Load a route into memory. Returns the exports from a route. */
+  loadRoute: () => any;
   /** nested routes */
   children: RouteNode[];
   /** Lazily get the React component */

--- a/packages/expo-router/src/__tests__/Route.test.node.ts
+++ b/packages/expo-router/src/__tests__/Route.test.node.ts
@@ -5,6 +5,13 @@ const asRouteNode = (route: string) =>
   ({
     children: [],
     dynamic: generateDynamic(route),
+    loadRoute(): any {
+      return {
+        default: function () {
+          return null;
+        },
+      };
+    },
     getComponent(): any {
       return function () {
         return null;

--- a/packages/expo-router/src/getLinkingConfig.ts
+++ b/packages/expo-router/src/getLinkingConfig.ts
@@ -20,6 +20,7 @@ type Screen =
   | {
       path: string;
       screens: Record<string, Screen>;
+      initialRouteName?: string;
     };
 
 // `[page]` -> `:page`
@@ -62,7 +63,15 @@ function convertRouteNodeToScreen(node: RouteNode): Screen {
     return path;
   }
   const screens = getReactNavigationScreensConfig(node.children);
-  return { path, screens };
+  return {
+    path,
+    screens,
+    // NOTE(EvanBacon): This is bad because it forces all Layout Routes
+    // to be loaded into memory. We should move towards a system where
+    // the initial route name is either loaded asynchronously in the Layout Route
+    // or defined via a file system convention.
+    initialRouteName: node.loadRoute().unstable_settings?.initialRouteName,
+  };
 }
 
 export function getReactNavigationScreensConfig(


### PR DESCRIPTION
# Motivation

- Add support for saving the context of a deep link. This is useful for modals or pages which require some navigational element to "go back".

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# Execution

- Added support for `export const unstable_settings = {}` from `_layout` files. This is marked as unstable because it breaks lazy loading of Layout Routes. We should replace it in the future for either an async mechanism in the layout component or a file name convention that marks a route as being the initial route.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

- Added a test folder where you can link to `/other` and reload the page. The back button should persist.
