### PR TITLE
docs: change docs to use metro 0.73.3 instead 0.73.1

### DIFF
--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -103,8 +103,8 @@ If you use npm, this requires npm 8.3.0 or higher. You can install this with `np
 ```json title=package.json
 {
   "overrides": {
-    "metro": "0.73.1",
-    "metro-resolver": "0.73.1"
+    "metro": "0.73.3",
+    "metro-resolver": "0.73.3"
   }
 }
 ```

--- a/packages/expo-router/package.json
+++ b/packages/expo-router/package.json
@@ -41,7 +41,7 @@
     "expo-constants": "*",
     "expo-linking": "*",
     "expo-status-bar": "*",
-    "metro": "~0.73.1",
+    "metro": "~0.73.3",
     "react-native-gesture-handler": "*",
     "react-native-reanimated": "*",
     "react-native-safe-area-context": "*",


### PR DESCRIPTION
# Motivation

This allows users that use NON-POSIX OS to be able to use the library.

