### PR TITLE
Added support for multiple dynamic route segments

### DIFF
--- a/apps/demo/app/(app)/(feed, explore, [user])/[user]/foo/[bar]/baz.tsx
+++ b/apps/demo/app/(app)/(feed, explore, [user])/[user]/foo/[bar]/baz.tsx
@@ -1,0 +1,38 @@
+import { Link } from "expo-router";
+import { StyleSheet, Text, View } from "react-native";
+
+export default function Page({ route }) {
+  return (
+    <View style={styles.container}>
+      <View style={styles.main}>
+        <Text style={styles.title}>User: {route.params?.user}</Text>
+        <Text style={styles.title}>Bar: {route.params?.bar}</Text>
+
+        <Link href="/([user])/compose">User -> Compose</Link>
+        <Link href={"../" + Math.random() + '/baz'}>Change same</Link>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: "center",
+    padding: 24,
+  },
+  main: {
+    flex: 1,
+    justifyContent: "center",
+    maxWidth: 960,
+    marginHorizontal: "auto",
+  },
+  title: {
+    fontSize: 64,
+    fontWeight: "bold",
+  },
+  subtitle: {
+    fontSize: 36,
+    color: "#38434D",
+  },
+});

--- a/packages/expo-router/src/Route.tsx
+++ b/packages/expo-router/src/Route.tsx
@@ -7,6 +7,8 @@ import { getNameFromFilePath, matchFragmentName } from "./matchers";
 export type PickPartial<T, K extends keyof T> = Omit<T, K> &
   Partial<Pick<T, K>>;
 
+export type DynamicConvention = { name: string; deep: boolean };
+
 export type RouteNode = {
   /** Load a route into memory. Returns the exports from a route. */
   loadRoute: () => any;
@@ -16,7 +18,7 @@ export type RouteNode = {
   /** nested routes */
   children: RouteNode[];
   /** Is the route a dynamic path */
-  dynamic: null | { name: string; deep: boolean };
+  dynamic: null | DynamicConvention[];
   /** `index`, `error-boundary`, etc. */
   route: string;
   /** require.context key, used for matching children. */
@@ -94,6 +96,7 @@ export function sortRoutesWithInitial(initialRouteName?: string) {
     return sortRoutes(a, b);
   };
 }
+
 export function sortRoutes(a: RouteNode, b: RouteNode): number {
   if (a.dynamic && !b.dynamic) {
     return 1;
@@ -102,11 +105,18 @@ export function sortRoutes(a: RouteNode, b: RouteNode): number {
     return -1;
   }
   if (a.dynamic && b.dynamic) {
-    if (a.dynamic.deep && !b.dynamic.deep) {
-      return 1;
+    if (a.dynamic.length !== b.dynamic.length) {
+      return b.dynamic.length - a.dynamic.length;
     }
-    if (!a.dynamic.deep && b.dynamic.deep) {
-      return -1;
+    for (let i = 0; i < a.dynamic.length; i++) {
+      const aDynamic = a.dynamic[i];
+      const bDynamic = b.dynamic[i];
+      if (aDynamic.deep && !bDynamic.deep) {
+        return 1;
+      }
+      if (!aDynamic.deep && bDynamic.deep) {
+        return -1;
+      }
     }
     return 0;
   }

--- a/packages/expo-router/src/__tests__/Route.test.node.ts
+++ b/packages/expo-router/src/__tests__/Route.test.node.ts
@@ -36,11 +36,18 @@ describe(sortRoutes, () => {
     expect(sortRoutes(asRouteNode("(zzz)"), asRouteNode("z"))).toBe(-1);
     expect(sortRoutes(asRouteNode("(zzz)"), asRouteNode("index"))).toBe(0);
   });
+  it(`sorts multiple dynamic routes higher than a single deep dynamic route`, () => {
+    // dynamic before deep dynamic
+    expect(sortRoutes(asRouteNode("[a]/[b]"), asRouteNode("[...a]"))).toBe(-1);
+    expect(sortRoutes(asRouteNode("[...a]"), asRouteNode("[a]/[b]"))).toBe(1);
+  });
+
   it(`sorts dynamic routes by priority`, () => {
     // dynamic before deep dynamic
     expect(sortRoutes(asRouteNode("[a]"), asRouteNode("[...a]"))).toBe(-1);
     // tied with two dynamic routes
     expect(sortRoutes(asRouteNode("[a]"), asRouteNode("[b]"))).toBe(0);
+    expect(sortRoutes(asRouteNode("[a]/[b]"), asRouteNode("[b]/[a]"))).toBe(0);
     // Lower priority
     expect(sortRoutes(asRouteNode("[a]"), asRouteNode("index"))).toBe(1);
     expect(sortRoutes(asRouteNode("[a]"), asRouteNode("a"))).toBe(1);
@@ -48,8 +55,14 @@ describe(sortRoutes, () => {
   });
   it(`sorts deep dynamic routes by priority`, () => {
     expect(sortRoutes(asRouteNode("[...a]"), asRouteNode("[...beta]"))).toBe(0);
+    expect(
+      sortRoutes(asRouteNode("[...a]/[b]"), asRouteNode("[...beta]/[c]"))
+    ).toBe(0);
     // Lower priority
     expect(sortRoutes(asRouteNode("[...a]"), asRouteNode("[b]"))).toBe(1);
+    expect(sortRoutes(asRouteNode("[...a]/[a]"), asRouteNode("[b]/[c]"))).toBe(
+      1
+    );
     expect(sortRoutes(asRouteNode("[...a]"), asRouteNode("index"))).toBe(1);
     expect(sortRoutes(asRouteNode("[...a]"), asRouteNode("a"))).toBe(1);
     expect(sortRoutes(asRouteNode("[...a]"), asRouteNode("(a)"))).toBe(1);

--- a/packages/expo-router/src/__tests__/getLinkingConfig.test.node.ts
+++ b/packages/expo-router/src/__tests__/getLinkingConfig.test.node.ts
@@ -18,19 +18,23 @@ const mockRoutes = [
     children: [
       {
         children: [],
-        dynamic: {
-          name: "deep",
-          deep: true,
-        },
+        dynamic: [
+          {
+            name: "deep",
+            deep: true,
+          },
+        ],
         route: "[...deep]",
         contextKey: "./(fragment)/[...deep].tsx",
       },
       {
         children: [],
-        dynamic: {
-          name: "dynamic",
-          deep: false,
-        },
+        dynamic: [
+          {
+            name: "dynamic",
+            deep: false,
+          },
+        ],
         route: "[dynamic]",
         contextKey: "./(fragment)/[dynamic].tsx",
       },
@@ -47,10 +51,12 @@ const mockRoutes = [
   },
   {
     children: [],
-    dynamic: {
-      name: "screen",
-      deep: true,
-    },
+    dynamic: [
+      {
+        name: "screen",
+        deep: true,
+      },
+    ],
     route: "other/nested/[...screen]",
     contextKey: "./other/nested/[...screen].js",
   },

--- a/packages/expo-router/src/__tests__/getRoutes.test.node.ts
+++ b/packages/expo-router/src/__tests__/getRoutes.test.node.ts
@@ -22,7 +22,7 @@ function createMockContextModule(
 const ROUTE_404 = {
   children: [],
   contextKey: "./[...404].tsx",
-  dynamic: { deep: true, name: "404" },
+  dynamic: [{ deep: true, name: "404" }],
   generated: true,
   internal: true,
   route: "[...404]",
@@ -221,7 +221,7 @@ describe(getRoutes, () => {
         {
           children: [],
           contextKey: "./[...404].tsx",
-          dynamic: { deep: true, name: "404" },
+          dynamic: [{ deep: true, name: "404" }],
           generated: true,
           internal: true,
           route: "[...404]",
@@ -277,20 +277,24 @@ describe(getRoutes, () => {
           {
             children: [],
             contextKey: "./[dynamic].tsx",
-            dynamic: {
-              deep: false,
-              name: "dynamic",
-            },
+            dynamic: [
+              {
+                deep: false,
+                name: "dynamic",
+              },
+            ],
 
             route: "[dynamic]",
           },
           {
             children: [],
             contextKey: "./[...deep].tsx",
-            dynamic: {
-              deep: true,
-              name: "deep",
-            },
+            dynamic: [
+              {
+                deep: true,
+                name: "deep",
+              },
+            ],
 
             route: "[...deep]",
           },
@@ -366,7 +370,12 @@ describe(getRoutes, () => {
             {
               children: [],
               contextKey: "./(stack)/user/[profile].tsx",
-              dynamic: null,
+              dynamic: [
+                {
+                  deep: false,
+                  name: "profile",
+                },
+              ],
               route: "user/[profile]",
             },
             {
@@ -380,7 +389,7 @@ describe(getRoutes, () => {
                 {
                   children: [],
                   contextKey: "./(stack)/user/settings/[...other].tsx",
-                  dynamic: { deep: true, name: "other" },
+                  dynamic: [{ deep: true, name: "other" }],
                   route: "[...other]",
                 },
               ],

--- a/packages/expo-router/src/__tests__/useScreens.test.node.tsx
+++ b/packages/expo-router/src/__tests__/useScreens.test.node.tsx
@@ -47,4 +47,20 @@ describe(createGetIdForRoute, () => {
     // Should never happen, but just in case.
     expect(getId({ params: { user: "" } })).toBe("[user]");
   });
+
+  it(`returns a function that picks multiple dynamic names from params`, () => {
+    const getId = createGetIdForRoute(createMockRoute("[user]/foo/[bar]"))!;
+    expect(getId).toBeDefined();
+
+    expect(getId({ params: { user: "bacon", bar: "hey" } })).toBe("bacon/hey");
+    // Fills partial params
+    expect(getId({ params: { user: "bacon" } })).toBe("bacon/[bar]");
+    // Unmatching param
+    expect(getId({ params: { baz: "foo" } })).toBe("[user]/[bar]");
+    // No params
+    expect(getId({ params: null })).toBe("[user]/[bar]");
+
+    // Should never happen, but just in case.
+    expect(getId({ params: { user: "" } })).toBe("[user]/[bar]");
+  });
 });

--- a/packages/expo-router/src/getRoutes.ts
+++ b/packages/expo-router/src/getRoutes.ts
@@ -1,4 +1,4 @@
-import { RouteNode } from "./Route";
+import { DynamicConvention, RouteNode } from "./Route";
 import {
   getNameFromFilePath,
   matchDeepDynamicRouteName,
@@ -92,11 +92,21 @@ function getTreeNodesAsRouteNodes(nodes: TreeNode[]): RouteNode[] {
   return nodes.map(treeNodeToRouteNode).flat().filter(Boolean) as RouteNode[];
 }
 
-export function generateDynamic(name: string) {
+export function generateDynamicFromSegment(
+  name: string
+): DynamicConvention | null {
   const deepDynamicName = matchDeepDynamicRouteName(name);
   const dynamicName = deepDynamicName ?? matchDynamicName(name);
 
   return dynamicName ? { name: dynamicName, deep: !!deepDynamicName } : null;
+}
+
+export function generateDynamic(name: string): RouteNode["dynamic"] {
+  const description = name
+    .split("/")
+    .map((segment) => generateDynamicFromSegment(segment))
+    .filter(Boolean) as DynamicConvention[];
+  return description.length === 0 ? null : description;
 }
 
 function collapseRouteSegments(route: string) {
@@ -334,7 +344,7 @@ function appendUnmatchedRoute(routes: RouteNode) {
       },
       route: "[...404]",
       contextKey: "./[...404].tsx",
-      dynamic: { name: "404", deep: true },
+      dynamic: [{ name: "404", deep: true }],
       children: [],
       generated: true,
       internal: true,


### PR DESCRIPTION
# Motivation

- Fixes https://github.com/expo/router/pull/105 by accounting for https://github.com/expo/router/pull/91
- Paths like `[user]/index.js` with no `[user]/_layout` would not automatically create the correct screen identifier, causing new screens to not be pushed. 

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# Execution

- Make dynamic an array
- Update the sorting algorithm to account for increased complexity.
- Make the automatic `getId` function apply all possible dynamic props to the identifier.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

- Add new tests for the getId method, and sorting algorithm.
- Fix broken test.
- Add screen for testing push animation on native platforms.

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
