### PR TITLE
Ensure useHref is always defined

### DIFF
--- a/packages/expo-router/src/ContextNavigator.tsx
+++ b/packages/expo-router/src/ContextNavigator.tsx
@@ -4,6 +4,7 @@ import { ContextNavigationContainer } from "./ContextNavigationContainer";
 import { RootRouteNodeContext, useRootRouteNodeContext } from "./context";
 import { getRoutes } from "./getRoutes";
 import { useTutorial } from "./onboard/useTutorial";
+import { InitialRootStateProvider } from "./rootStateContext";
 import { RequireContext } from "./types";
 import { getQualifiedRouteComponent } from "./useScreens";
 import { SplashScreen } from "./views/Splash";
@@ -39,7 +40,9 @@ export function ContextNavigator({ context }: { context: RequireContext }) {
   return (
     <RootRouteNodeProvider context={context}>
       <ContextNavigationContainer>
-        <RootRoute />
+        <InitialRootStateProvider>
+          <RootRoute />
+        </InitialRootStateProvider>
       </ContextNavigationContainer>
     </RootRouteNodeProvider>
   );
@@ -47,7 +50,6 @@ export function ContextNavigator({ context }: { context: RequireContext }) {
 
 function RootRoute() {
   const root = useRootRouteNodeContext();
-
   const Component = getQualifiedRouteComponent(root);
   // @ts-expect-error: TODO: Drop navigation and route props
   return <Component />;

--- a/packages/expo-router/src/fork/__tests__/getPathFromState-upstream.test.node.ts
+++ b/packages/expo-router/src/fork/__tests__/getPathFromState-upstream.test.node.ts
@@ -158,6 +158,94 @@ type State = PartialState<NavigationState>;
   });
 });
 
+it("does not collapse conventions", () => {
+  expect(
+    getPathFromState(
+      {
+        stale: false,
+        type: "stack",
+        key: "stack-As9iX2L8B1j6ZjV3xN8aQ",
+        index: 0,
+        routeNames: ["(app)"],
+        routes: [
+          {
+            name: "(app)",
+            params: {
+              user: "bacon",
+            },
+            state: {
+              stale: false,
+              type: "stack",
+              key: "stack-TihHf0Ci6SaO_avdb9IAz",
+              index: 0,
+              routeNames: ["[user]"],
+              routes: [
+                {
+                  name: "[user]",
+                  params: {
+                    user: "bacon",
+                  },
+                  state: {
+                    stale: false,
+                    type: "tab",
+                    key: "tab-n3xlu2kPlKh1VOAQWJbEb",
+                    index: 1,
+                    routeNames: ["index", "related"],
+                    history: [
+                      {
+                        type: "route",
+                        key: "index-z-ZR1oYFE3kHksOXi4L9j",
+                      },
+                      {
+                        type: "route",
+                        key: "related-WWyKJe4_3X-PyqW5MIzN4",
+                      },
+                    ],
+                    routes: [
+                      {
+                        name: "index",
+                        key: "index-z-ZR1oYFE3kHksOXi4L9j",
+                      },
+                      {
+                        name: "related",
+                        params: {
+                          user: "bacon",
+                        },
+                        path: "/bacon/related",
+                        key: "related-WWyKJe4_3X-PyqW5MIzN4",
+                      },
+                    ],
+                  },
+                  key: "[user]-9qb40LvrbVOw4HArHBQQN",
+                },
+              ],
+            },
+            key: "(app)-eHHi2MUdVaFK_IshK8Y2J",
+          },
+        ],
+      },
+      {
+        screens: {
+          "(app)": {
+            path: "(app)",
+            screens: {
+              "[user]": {
+                path: ":user",
+                screens: {
+                  index: "",
+                  related: "related",
+                },
+              },
+            },
+          },
+        },
+        preserveDynamicRoutes: true,
+        preserveFragments: true,
+      } as any
+    )
+  ).toBe("/(app)/[user]/related?user=bacon");
+});
+
 it("converts state to path string with config", () => {
   const path = "/few/bar/sweet/apple/baz/jane?id=x10&valid=true";
   const config = {

--- a/packages/expo-router/src/fork/getPathFromState.ts
+++ b/packages/expo-router/src/fork/getPathFromState.ts
@@ -371,17 +371,18 @@ function getPathFromResolvedState(
     } else {
       // Finished crawling state.
 
+      const outputParams = preserveDynamicRoutes ? params : focusedParams;
       // Check for query params before exiting.
-      if (focusedParams) {
-        for (const param in focusedParams) {
+      if (outputParams) {
+        for (const param in outputParams) {
           // TODO: This is not good. We shouldn't squat strings named "undefined".
-          if (focusedParams[param] === "undefined") {
+          if (outputParams[param] === "undefined") {
             // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
-            delete focusedParams[param];
+            delete outputParams[param];
           }
         }
 
-        const query = queryString.stringify(focusedParams, { sort: false });
+        const query = queryString.stringify(outputParams, { sort: false });
 
         if (query) {
           path += `?${query}`;

--- a/packages/expo-router/src/rootStateContext.tsx
+++ b/packages/expo-router/src/rootStateContext.tsx
@@ -1,0 +1,71 @@
+import React, { createContext, useContext, useEffect, useState } from "react";
+import URL from "url-parse";
+
+import { State } from "./fork/getPathFromState";
+import { useLinkingContext } from "./link/useLinkingContext";
+
+function useResolvedPromise<T>(promise: Promise<T> | undefined) {
+  const [resolved, setResolved] = useState<T | undefined>();
+
+  useEffect(() => {
+    if (promise) {
+      promise.then(setResolved);
+    }
+  }, [promise]);
+
+  return resolved;
+}
+
+function useHackInitialRootState() {
+  const linking = useLinkingContext();
+  const url = useResolvedPromise(linking.getInitialURL() as Promise<string>);
+  const [state, setState] = useState<State | null>(null);
+
+  useEffect(() => {
+    if (url) {
+      const parsed = URL(url);
+      // TODO: Add hashes to the path
+      const urlWithoutOrigin = parsed.pathname + parsed.query;
+
+      setState(linking.getStateFromPath(urlWithoutOrigin, linking.config)!);
+    }
+  }, [url, linking]);
+
+  return state;
+}
+
+export const InitialRootStateContext = createContext<State | null>(null);
+
+if (process.env.NODE_ENV !== "production") {
+  InitialRootStateContext.displayName = "InitialRootStateContext";
+}
+
+export function useInitialRootStateContext() {
+  const state = useContext(InitialRootStateContext);
+  if (!state) {
+    throw new Error(
+      "useInitialRootStateContext is being used outside of InitialRootStateContext.Provider"
+    );
+  }
+  return state;
+}
+
+export function InitialRootStateProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const state = useHackInitialRootState();
+
+  // Prevent all rendering until we have the initial root state.
+  // Probably React Navigation should be doing this for us.
+  if (!state) {
+    return null;
+  }
+
+  return (
+    <InitialRootStateContext.Provider value={state}>
+      {children}
+    </InitialRootStateContext.Provider>
+  );
+}


### PR DESCRIPTION
# Motivation

- The `route` prop can often be incorrect or missing params, this is not acceptable for data loading.
- Ensure the `useHref` hook always returns the correct data wherever it's rendered.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# Execution

- Added a new context that delays all rendering until the initial root state is calculated. This is then used when the root navigation state is not defined.
- Implements the same functionality as https://github.com/expo/router/pull/139 by preventing the calculation of the nearest Layout Route, in favor of the root layout state.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

- Added new tests to ensure the params are aggressively applied to all routes.

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
