### PR TITLE
Fix RootNavigation onReady method

### DIFF
--- a/packages/expo-router/src/ContextNavigationContainer.tsx
+++ b/packages/expo-router/src/ContextNavigationContainer.tsx
@@ -72,7 +72,7 @@ function InternalContextNavigationContainer(props: object) {
 
   React.useEffect(() => {
     contextProps.onReady?.();
-  }, [!!contextProps?.onReady])
+  }, [!!contextProps?.onReady]);
 
   return (
     <RootNavigationRef.Provider value={{ ref }}>

--- a/packages/expo-router/src/ContextNavigationContainer.tsx
+++ b/packages/expo-router/src/ContextNavigationContainer.tsx
@@ -70,6 +70,10 @@ function InternalContextNavigationContainer(props: object) {
     return linking;
   }, [root]);
 
+  React.useEffect(()=>{
+    contextProps.onReady?.();
+  }, [!!(contextProps?.onReady)])
+
   return (
     <RootNavigationRef.Provider value={{ ref }}>
       {!isReady && <SplashScreen />}
@@ -80,7 +84,6 @@ function InternalContextNavigationContainer(props: object) {
         linking={linking}
         ref={navigationRef}
         onReady={() => {
-          contextProps.onReady?.();
           setReady(true);
         }}
       />

--- a/packages/expo-router/src/ContextNavigationContainer.tsx
+++ b/packages/expo-router/src/ContextNavigationContainer.tsx
@@ -70,9 +70,9 @@ function InternalContextNavigationContainer(props: object) {
     return linking;
   }, [root]);
 
-  React.useEffect(()=>{
+  React.useEffect(() => {
     contextProps.onReady?.();
-  }, [!!(contextProps?.onReady)])
+  }, [!!contextProps?.onReady])
 
   return (
     <RootNavigationRef.Provider value={{ ref }}>


### PR DESCRIPTION
# Motivation

The contextProps.onReady handler was failing to execute because the RootNavigation onReady method was executing before setProps could set the contextProps, as detailed in #170.

# Execution

This pull request resolves this issue by using the RootNavigation onReady method to setReady, and using a React.useEffect hook to check if contextProps.onReady is present, and if so execute it.  Using contextProps.onReady as a scope on useEffect ensures it only renders once on component render.

```
  React.useEffect(()=>{
    contextProps.onReady?.();
  }, [!!(contextProps?.onReady)])
  ```

Closes #170

# Test Plan

Some console.logs onReady and onState change show they execute, and using `RootContainer.getRef()` no longer causes the infinite render loop.

With this change, react-navigation screen tracking can now be implemented.

```

  const navigationRef = RootContainer.getRef();
  const routeNameRef = useRef();

  return (
    <>
    <RootContainer 
      onReady={(ref) => {
        routeNameRef.current = navigationRef.getCurrentRoute().name;
      }}
      onStateChange={async () => {
        const previousRouteName = routeNameRef.current;
        const currentRouteName = navigationRef.getCurrentRoute().name;

        if (previousRouteName !== currentRouteName) {
          routeNameRef.current = currentRouteName;
          console.log('new route', currentRouteName)
        }
      }}
    />
    ...
    </>
  )
```