### PR TITLE
feat: add themes guide and drop support for `theme` in the `RootContainer`

### DIFF
--- a/docs/docs/features/container.md
+++ b/docs/docs/features/container.md
@@ -3,7 +3,7 @@ title: Navigation Container
 sidebar_position: 6
 ---
 
-The global React Navigation [`<NavigationContainer />`](https://reactnavigation.org/docs/navigation-container/) is managed by Expo Router, you can pass it props like `theme` from any screen by using the `<RootContainer />` component.
+The global React Navigation [`<NavigationContainer />`](https://reactnavigation.org/docs/navigation-container/) is managed by Expo Router, you can pass it props like `theme` from any screen by using the `<RootContainer />` component but this is discouraged.
 
 ```tsx title=app/_layout.tsx
 import { RootContainer, Children } from "expo-router";
@@ -53,6 +53,10 @@ function Page() {
 ## Restrictions
 
 The navigation container has many props that should not be used with Expo Router. Carefully reconsider how your app is using the following props before migrating to Expo Router.
+
+### `theme`
+
+Use the `<ThemeProvider />` component instead. Learn more in the [Themes guide](/docs/guides/themes).
 
 ### `onReady`
 

--- a/docs/docs/guides/themes.md
+++ b/docs/docs/guides/themes.md
@@ -1,0 +1,29 @@
+---
+title: Themes
+---
+
+In React Navigation, you set the theme for the entire app using the [`<NavigationContainer />`](https://reactnavigation.org/docs/navigation-container/#theme) component. Expo Router manages the root container for you, so instead you should set the theme using the `ThemeProvider` directly.
+
+```js title=app/_layout.tsx
+
+import {
+  ThemeProvider,
+  DarkTheme,
+  DefaultTheme,
+  useTheme,
+} from "@react-navigation/native";
+
+import { Children } from 'expo-router';
+
+export default function RootLayout() {
+    return (
+        {/* All layouts inside this provider will use the dark theme. */}
+        // highlight-next-line
+        <ThemeProvider value={DarkTheme}>
+            <Children />
+        </ThemeProvider>
+    );
+}
+```
+
+You can use this technique at any layer of the app to set the theme for a specific layout. The current theme can be accessed with `useTheme` from `@react-navigation/native`.

--- a/packages/expo-router/src/ContextNavigationContainer.tsx
+++ b/packages/expo-router/src/ContextNavigationContainer.tsx
@@ -101,6 +101,7 @@ export function RootContainer(
   React.useEffect(() => {
     if (process.env.NODE_ENV !== "production") {
       const restrictedProps = [
+        "theme",
         "fallback",
         "independent",
         "onReady",


### PR DESCRIPTION
# Motivation

I'm attempting to deprecate the `<RootContainer />` component as it's prone to bugs and the global provider will cause lots of updates across the entire app. The `theme` property was the last real reason to use `<RootContainer />` as a component.

# Execution

- Add a guide that shows how to use the `ThemeProvider` in a layout route to set the theme for a particular boundary. This is nice because you can swap the theme per-route.
- Add `theme` to the list of warned / restricted props in RootContainer.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
