### PR TITLE
[experimental] refactor hooks to work more like the web

### DIFF
--- a/apps/demo/app/(app)/(feed, explore, [user])/_layout.tsx
+++ b/apps/demo/app/(app)/(feed, explore, [user])/_layout.tsx
@@ -1,5 +1,12 @@
 import { Stack, Tabs } from "expo-router";
 
+export const unstable_settings = {
+  // initialRouteName: "feed",
+  "[user]": {
+    initialRouteName: "explore",
+  },
+};
+
 export default function StackLayout({ segment }) {
   return <Stack />;
 }

--- a/apps/demo/etc/urlBar.tsx
+++ b/apps/demo/etc/urlBar.tsx
@@ -1,9 +1,9 @@
 import { Text, View } from "@bacons/react-views";
-import { useHref } from "expo-router";
+import { usePathname } from "expo-router";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 export function UrlBar() {
-  const location = useHref();
+  const pathname = usePathname();
   const { bottom } = useSafeAreaInsets();
   return (
     <View
@@ -25,7 +25,7 @@ export function UrlBar() {
           fontSize: 16,
         }}
       >
-        {location.href}
+        {pathname}
       </Text>
     </View>
   );

--- a/docs/docs/features/layout-routes.md
+++ b/docs/docs/features/layout-routes.md
@@ -129,3 +129,16 @@ export default function Layout() {
 ```
 
 Now deep linking directly to `/other` or reloading the page will continue to show the back arrow.
+
+When using clone syntax `(foo, bar)` you can specify the name of a group in the `unstable_settings` object.
+
+```js
+export const unstable_settings = {
+  // Used for `(foo)`
+  initialRouteName: "first",
+  // Used for `(bar)`
+  bar: {
+    initialRouteName: "second",
+  },
+};
+```

--- a/docs/docs/features/layouts.md
+++ b/docs/docs/features/layouts.md
@@ -87,7 +87,7 @@ Custom layouts have an internal context that is ignored when using the `<Childre
 import { View } from "react-native";
 import { TabRouter } from "@react-navigation/native";
 
-import { Layout, useHref, Children, Link } from "expo-router";
+import { Layout, useSegments, Children, Link } from "expo-router";
 
 export default function App() {
   return (
@@ -102,7 +102,7 @@ export default function App() {
 function Header() {
   const { navigation, state, descriptors, router } = Layout.useContext();
 
-  const { pathname } = useHref();
+  const [segment] = useSegments();
 
   return (
     <View>
@@ -111,7 +111,7 @@ function Header() {
         href="/profile"
         // Use `pathname` to determine if the link is active.
         // highlight-next-line
-        style={[pathname === "/profile" && { color: "blue" }]}
+        style={[segment === "profile" && { color: "blue" }]}
       >
         Profile
       </Link>

--- a/docs/docs/features/linking.md
+++ b/docs/docs/features/linking.md
@@ -3,11 +3,9 @@ title: Linking
 sidebar_position: 2
 ---
 
-The `expo-router` `Link` component supports client-side navigation to a route. It is similar to the `Link` component in `react-router-dom` and `next/link`.
+## Link Component
 
-When JavaScript is disabled or the client is offline, the `Link` component will render a regular `<a>` element. Otherwise, the default behavior will be intercepted and the client-side router will navigate to the route (faster and smoother).
-
-Meaning you get the best of both worlds: a fast client-side navigation experience, and a fallback for when JavaScript is disabled or hasn't loaded yet.
+Use the `<Link />` component to navigate between pages. This is conceptually similar to the `<a>` element in HTML.
 
 ```tsx
 import { Link } from "expo-router";
@@ -21,61 +19,57 @@ export default function Page() {
 }
 ```
 
-Try to use the `Link` component whenever possible as it renders the correct semantic HTML element on web. This is important for accessibility and SEO.
-
 ## Imperative API
 
-For more advanced use cases, you can use the imperative `useLink` hook to navigate imperatively.
+For more advanced use cases, you can use the imperative `useRouter()` hook to navigate imperatively.
 
 ```js
 import { View, Text } from "react-native";
-import { useLink } from "expo-router";
+import { useRouter } from "expo-router";
 
 export default function Page() {
-  const link = useLink();
+  const router = useRouter();
 
   return (
     <View>
-      <Text onPress={() => link.push("/profile/settings")}>Settings</Text>
+      <Text onPress={() => router.push("/profile/settings")}>Settings</Text>
     </View>
   );
 }
 ```
 
-Prefer the `useLink` hook to `useNavigation` from React Navigation as `useLink` works much closer to the `<Link />` component.
-
-## `useLink` API
+## `useRouter`
 
 - **push**: _`(href: Href) => void`_ Navigate to a route. You can provide a full path like `/profile/settings` or a relative path like `../settings`. Navigate to dynamic routes by passing an object like `{ pathname: 'profile', params: { id: '123' } }`.
 - **replace**: _`(href: Href) => void`_ Same API as `push` but replaces the current route in the history instead of pushing a new one. This is useful for redirects.
 - **back**: _`() => void`_ Navigate to a route. You can provide a full path like `/profile/settings` or a relative path like `../settings`. Navigate to dynamic routes by passing an object like `{ pathname: 'profile', params: { id: '123' } }`.
 
-> This API is similar to Next.js's `useRouter` hook, but adjusted to work around the state management requirements of native.
-
-## `Href` type
+### `Href` type
 
 The `Href` type is a union of the following types:
 
 - **string**: A full path like `/profile/settings` or a relative path like `../settings`.
 - **object**: An object with a `pathname` and optional `params` object. The `pathname` can be a full path like `/profile/settings` or a relative path like `../settings`. The `params` can be an object of key/value pairs.
 
-## `useHref` API
+## `usePathname`
 
-The `useHref` hook provides the current location information for a route.
+Returns the currently selected route location without search parameters. e.g. `/acme?foo=bar` -> `/acme`. Segments will be normalized: `/[id]?id=normal` -> `/normal`
 
-- **href**: _`string`_ The relative normalized path that would show up in the URL bar.
-- **pathname**: _`string`_ The relative template path reflecting the current route. e.g. `/profile/[id]`.
-- **params**: _`Record<string, any>`_ Query parameters for the current route. e.g. `{ id: '123' }`.
+## `useSearchParams`
 
-Given a route at `app/profile/[id].tsx` if the hook is called while the URL is `/profile/123`, the results of `useHref` would be as follows:
+Returns `URLSearchParameters` for the currently selected route.
+
+Given a route at `app/profile/[id].tsx` if the hook is called while the URL is `/profile/123`, the results of `useSearchParams` would be as follows:
 
 ```js
 {
-  href: "/profile/123",
-  pathname: "/profile/[id]",
-  params: { id: "123" },
+  id: "123";
 }
 ```
+
+## `useSegments`
+
+Returns a list of segments for the currently selected route. Segments are not normalized, so they will be the same as the file path. e.g. `/[id]?id=normal` -> `["[id]"]`
 
 ## Navigation prop
 
@@ -127,19 +121,19 @@ export default function Page() {
 }
 ```
 
-You can also redirect imperatively using the `useLink` hook:
+You can also redirect imperatively using the `useRouter` hook:
 
 ```js
-import { useLink, useFocusEffect } from "expo-router";
+import { useRouter, useFocusEffect } from "expo-router";
 
 function MyScreen() {
-  const link = useLink();
+  const router = useRouter();
 
   useFocusEffect(() => {
     // Call the replace method to redirect to a new route without adding to the history.
     // We do this in a useFocusEffect to ensure the redirect happens every time the screen
     // is focused.
-    link.replace("/profile/settings");
+    router.replace("/profile/settings");
   });
 
   return <Text>My Screen</Text>;

--- a/docs/docs/guides/screen-tracking.md
+++ b/docs/docs/guides/screen-tracking.md
@@ -15,15 +15,16 @@ app/
 
 ```js title=app/_layout.js
 import { useEffect } from "react";
-import { useHref, Children } from "expo-router";
+import { usePathname, useSearchParams, Children } from "expo-router";
 
 export default function Layout() {
-  const location = useHref();
+  const pathname = usePathname();
+  const params = useSearchParams();
 
   // Track the location in your analytics provider here.
   useEffect(() => {
-    analytics.track(location);
-  }, [location]);
+    analytics.track({ pathname, params });
+  }, [pathname, params]);
 
   // Export all the children routes in the most basic way.
   return <Children />;

--- a/docs/docs/migration/from-react-navigation.md
+++ b/docs/docs/migration/from-react-navigation.md
@@ -50,6 +50,8 @@ import { Stack } from "expo-router";
 
 Use `Link` from `expo-router` as this provides child context.
 
+Migrate from `useNavigation()` to `useRouter()` for navigating between screens.
+
 ### Screen Options
 
 > Think of this component like a `<head />` component from web frameworks.

--- a/packages/expo-router/package.json
+++ b/packages/expo-router/package.json
@@ -72,6 +72,7 @@
     "react-native-screens": "~3.15.0"
   },
   "dependencies": {
+    "url": "^0.11.0",
     "@bacons/expo-metro-runtime": "^2.0.1",
     "@bacons/react-views": "^1.1.3",
     "@radix-ui/react-slot": "^1.0.0",

--- a/packages/expo-router/src/ContextNavigator.tsx
+++ b/packages/expo-router/src/ContextNavigator.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo } from "react";
 
 import { ContextNavigationContainer } from "./ContextNavigationContainer";
+import { LocationProvider } from "./LocationProvider";
 import { RootRouteNodeContext, useRootRouteNodeContext } from "./context";
 import { getRoutes } from "./getRoutes";
 import { useTutorial } from "./onboard/useTutorial";
@@ -8,7 +9,6 @@ import { InitialRootStateProvider } from "./rootStateContext";
 import { RequireContext } from "./types";
 import { getQualifiedRouteComponent } from "./useScreens";
 import { SplashScreen } from "./views/Splash";
-import { LocationProvider } from "./LocationProvider";
 
 function useContextModuleAsRoutes(context: RequireContext) {
   // TODO: Is this an optimal hook dependency?

--- a/packages/expo-router/src/ContextNavigator.tsx
+++ b/packages/expo-router/src/ContextNavigator.tsx
@@ -8,6 +8,7 @@ import { InitialRootStateProvider } from "./rootStateContext";
 import { RequireContext } from "./types";
 import { getQualifiedRouteComponent } from "./useScreens";
 import { SplashScreen } from "./views/Splash";
+import { LocationProvider } from "./LocationProvider";
 
 function useContextModuleAsRoutes(context: RequireContext) {
   // TODO: Is this an optimal hook dependency?
@@ -41,7 +42,9 @@ export function ContextNavigator({ context }: { context: RequireContext }) {
     <RootRouteNodeProvider context={context}>
       <ContextNavigationContainer>
         <InitialRootStateProvider>
-          <RootRoute />
+          <LocationProvider>
+            <RootRoute />
+          </LocationProvider>
         </InitialRootStateProvider>
       </ContextNavigationContainer>
     </RootRouteNodeProvider>

--- a/packages/expo-router/src/LocationProvider.tsx
+++ b/packages/expo-router/src/LocationProvider.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { URLSearchParams } from "url";
 
 import { RootContainer } from "./ContextNavigationContainer";
 import getPathFromState, { State } from "./fork/getPathFromState";
@@ -16,8 +15,11 @@ function getRouteInfoFromState(
   getPathFromState: (state: State, asPath: boolean) => string,
   state: State
 ): UrlObject {
+  const path = getPathFromState(state, false);
+
   return {
-    pathname: getPathFromState(state, false),
+    pathname: path.split("?")["0"],
+    //  TODO: This sometimes returns: `params=[object Object]&screen=XX&path=XX&initial=true`
     ...getNormalizedStatePath(getPathFromState(state, true)),
   };
 }

--- a/packages/expo-router/src/LocationProvider.tsx
+++ b/packages/expo-router/src/LocationProvider.tsx
@@ -122,7 +122,8 @@ function getNormalizedStatePath(
   const [pathname, querystring] = statePath.split("?");
 
   return {
-    segments: pathname.split("/"),
+    // Strip empty path at the start
+    segments: pathname.split("/").filter(Boolean),
     // TODO: This is not efficient, we should generate based on the state instead
     // of converting to string then back to object
     params: new URLSearchParams(querystring),

--- a/packages/expo-router/src/LocationProvider.tsx
+++ b/packages/expo-router/src/LocationProvider.tsx
@@ -1,0 +1,170 @@
+import React from "react";
+import { URLSearchParams } from "url";
+
+import { RootContainer } from "./ContextNavigationContainer";
+import getPathFromState, { State } from "./fork/getPathFromState";
+import { useLinkingContext } from "./link/useLinkingContext";
+import { useInitialRootStateContext } from "./rootStateContext";
+
+type UrlObject = {
+  pathname: string;
+  readonly params: URLSearchParams;
+  segments: string[];
+};
+
+function getRouteInfoFromState(
+  getPathFromState: (state: State, asPath: boolean) => string,
+  state: State
+): UrlObject {
+  return {
+    pathname: getPathFromState(state, false),
+    ...getNormalizedStatePath(getPathFromState(state, true)),
+  };
+}
+
+function compareShallowRecords(a: Record<string, any>, b: Record<string, any>) {
+  const aKeys = Object.keys(a);
+  const bKeys = Object.keys(b);
+
+  if (aKeys.length !== bKeys.length) {
+    return false;
+  }
+
+  for (const key of aKeys) {
+    if (a[key] !== b[key]) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+function compareRouteInfo(a: UrlObject, b: UrlObject) {
+  return (
+    a.segments.length === b.segments.length &&
+    a.segments.every((segment, index) => segment === b.segments[index]) &&
+    a.pathname === b.pathname &&
+    compareShallowRecords(a.params, b.params)
+  );
+}
+
+function useUrlObject(): UrlObject {
+  const initialRootState = useInitialRootStateContext();
+  const getPathFromState = useGetPathFromState();
+
+  const [routeInfo, setRouteInfo] = React.useState<UrlObject>(
+    getRouteInfoFromState(
+      getPathFromState,
+      // If the root state (from upstream) is not ready, use the hacky initial state.
+      // Initial state can be generate because it assumes the linking configuration never changes.
+      RootContainer.getRef().getRootState() ?? initialRootState
+    )
+  );
+
+  const routeInfoRef = React.useRef(routeInfo);
+
+  React.useEffect(() => {
+    routeInfoRef.current = routeInfo;
+  }, [routeInfo]);
+
+  const maybeUpdateRouteInfo = React.useCallback(
+    (state: State) => {
+      // Prevent unnecessary updates
+      const newRouteInfo = getRouteInfoFromState(getPathFromState, state);
+      if (!compareRouteInfo(routeInfoRef.current, newRouteInfo)) {
+        setRouteInfo(newRouteInfo);
+      }
+    },
+    [
+      // TODO: This probably never changes
+      getPathFromState,
+    ]
+  );
+
+  React.useEffect(() => {
+    const rootNavigation = RootContainer.getRef();
+
+    return rootNavigation.addListener("state", ({ data }) => {
+      // Attempt to use the complete state from the root, otherwise this will default to
+      // sending events from the nearest layout.
+      const navigationState =
+        rootNavigation.getRootState() ?? (data.state as unknown as State);
+      // NOTE(EvanBacon): It's probably worth asserting if the root state is missing here.
+      maybeUpdateRouteInfo(navigationState);
+    });
+  }, [maybeUpdateRouteInfo]);
+
+  return routeInfo;
+}
+
+function useGetPathFromState() {
+  const linking = useLinkingContext();
+
+  return React.useCallback(
+    (state: Parameters<typeof getPathFromState>[0], asPath: boolean) => {
+      return linking.getPathFromState(state, {
+        ...linking.config,
+        // @ts-expect-error
+        preserveDynamicRoutes: asPath,
+        preserveFragments: asPath,
+      });
+    },
+    [linking]
+  );
+}
+
+// TODO: Split up getPathFromState to return all this info at once.
+function getNormalizedStatePath(
+  statePath: string
+): Omit<UrlObject, "pathname"> {
+  const [pathname, querystring] = statePath.split("?");
+
+  return {
+    segments: pathname.split("/"),
+    // TODO: This is not efficient, we should generate based on the state instead
+    // of converting to string then back to object
+    params: new URLSearchParams(querystring),
+  };
+}
+
+const LocationContext = React.createContext<UrlObject | undefined>(undefined);
+
+if (process.env.NODE_ENV !== "production") {
+  LocationContext.displayName = "LocationContext";
+}
+
+export function LocationProvider({ children }: { children: React.ReactNode }) {
+  return (
+    <LocationContext.Provider value={useUrlObject()}>
+      {children}
+    </LocationContext.Provider>
+  );
+}
+
+function useLocation() {
+  const location = React.useContext(LocationContext);
+
+  if (!location) {
+    throw new Error(
+      "Location context is missing. Make sure you are rendering a <LocationProvider />."
+    );
+  }
+
+  return location;
+}
+
+/** @returns Currently selected route as a normalized string without search parameters. e.g. `/acme?foo=bar` -> `/acme`. Segments will be normalized: `/[id]?id=normal` -> `/normal` */
+export function usePathname(): string {
+  return useLocation().pathname;
+}
+
+/** @returns Current URL Search Parameters. */
+export function useSearchParams(): URLSearchParams {
+  // TODO: Make this readonly
+  return useLocation().params;
+}
+
+/** @returns array of selected segments. */
+export function useSegments(): string[] {
+  return useLocation().segments;
+}

--- a/packages/expo-router/src/exports.ts
+++ b/packages/expo-router/src/exports.ts
@@ -1,19 +1,22 @@
-export { useFocusEffect } from "@react-navigation/native";
-export { ErrorBoundaryProps } from "./views/Try";
+// Expo Router API
+export { useRouter } from "./link/useRouter";
+export { usePathname, useSearchParams, useSegments } from "./LocationProvider";
+export { Link, Redirect } from "./link/Link";
 
 export { withLayoutContext } from "./layouts/withLayoutContext";
+export { Layout, Children } from "./views/Layout";
 
+// Expo Router Views
 export { ExpoRoot } from "./views/Root";
 export { Unmatched } from "./views/Unmatched";
+export { ErrorBoundaryProps } from "./views/Try";
 export { ErrorBoundary } from "./views/ErrorBoundary";
 
-export { Layout, Children } from "./views/Layout";
-export { Link, Redirect } from "./link/Link";
-export { useRouter } from "./link/useRouter";
-export { RootContainer } from "./ContextNavigationContainer";
-
+// Platform
+export { SplashScreen } from "./views/Splash";
 export * as Linking from "./link/linking";
 
-export { SplashScreen } from "./views/Splash";
-export { usePathname, useSearchParams, useSegments } from "./LocationProvider";
+// React Navigation
 export { useNavigation } from "./useNavigation";
+export { RootContainer } from "./ContextNavigationContainer";
+export { useFocusEffect } from "@react-navigation/native";

--- a/packages/expo-router/src/exports.ts
+++ b/packages/expo-router/src/exports.ts
@@ -9,11 +9,11 @@ export { ErrorBoundary } from "./views/ErrorBoundary";
 
 export { Layout, Children } from "./views/Layout";
 export { Link, Redirect } from "./link/Link";
-export { useLink } from "./link/useLink";
+export { useRouter } from "./link/useRouter";
 export { RootContainer } from "./ContextNavigationContainer";
 
 export * as Linking from "./link/linking";
 
 export { SplashScreen } from "./views/Splash";
-export { useHref } from "./link/useHref";
+export { usePathname, useSearchParams, useSegments } from "./LocationProvider";
 export { useNavigation } from "./useNavigation";

--- a/packages/expo-router/src/getLinkingConfig.ts
+++ b/packages/expo-router/src/getLinkingConfig.ts
@@ -68,7 +68,7 @@ function convertRouteNodeToScreen(node: RouteNode): Screen {
     // to be loaded into memory. We should move towards a system where
     // the initial route name is either loaded asynchronously in the Layout Route
     // or defined via a file system convention.
-    initialRouteName: node.loadRoute?.().unstable_settings?.initialRouteName,
+    initialRouteName: node.initialRouteName,
   };
 }
 

--- a/packages/expo-router/src/getRoutes.ts
+++ b/packages/expo-router/src/getRoutes.ts
@@ -139,11 +139,12 @@ function applyDefaultInitialRouteName(node: RouteNode): RouteNode {
   const loaded = node.loadRoute();
 
   if (loaded.unstable_settings) {
-    // Allow unstable_settings={ initialRouteName: '...' } to override the default initial route name.
-    const definedInitialRouteName = loaded.unstable_settings.initialRouteName;
     // Allow unstable_settings={ 'custom': { initialRouteName: '...' } } to override the less specific initial route name.
     const groupSpecificInitialRouteName =
       loaded.unstable_settings?.[fragmentName]?.initialRouteName;
+
+    // Allow unstable_settings={ initialRouteName: '...' } to override the default initial route name.
+    const definedInitialRouteName = loaded.unstable_settings.initialRouteName;
 
     initialRouteName =
       groupSpecificInitialRouteName ??

--- a/packages/expo-router/src/getRoutes.ts
+++ b/packages/expo-router/src/getRoutes.ts
@@ -135,26 +135,26 @@ function applyDefaultInitialRouteName(node: RouteNode): RouteNode {
 
   // Guess at the initial route based on the fragment name.
   // TODO(EvanBacon): Perhaps we should attempt to warn when the fragment doesn't match any child routes.
-  const initialRouteName = getDefaultInitialRoute(node, fragmentName)?.route;
-  const route = {
-    ...node,
-    loadRoute() {
-      const { unstable_settings, ...route } = node.loadRoute();
-      return {
-        ...route,
-        unstable_settings: {
-          initialRouteName:
-            unstable_settings?.initialRouteName ?? initialRouteName,
-          // Allow overriding the initial route name using the layout settings.
-          ...unstable_settings,
-        },
-      };
-    },
-  };
-  if (initialRouteName != null) {
-    route.initialRouteName = initialRouteName;
+  let initialRouteName = getDefaultInitialRoute(node, fragmentName)?.route;
+  const loaded = node.loadRoute();
+
+  if (loaded.unstable_settings) {
+    // Allow unstable_settings={ initialRouteName: '...' } to override the default initial route name.
+    const definedInitialRouteName = loaded.unstable_settings.initialRouteName;
+    // Allow unstable_settings={ 'custom': { initialRouteName: '...' } } to override the less specific initial route name.
+    const groupSpecificInitialRouteName =
+      loaded.unstable_settings?.[fragmentName]?.initialRouteName;
+
+    initialRouteName =
+      groupSpecificInitialRouteName ??
+      definedInitialRouteName ??
+      initialRouteName;
   }
-  return route;
+
+  return {
+    ...node,
+    initialRouteName,
+  };
 }
 
 function cloneFragmentRoute(

--- a/packages/expo-router/src/link/Link.tsx
+++ b/packages/expo-router/src/link/Link.tsx
@@ -7,8 +7,8 @@ import * as React from "react";
 import { GestureResponderEvent, Platform } from "react-native";
 
 import { Href, resolveHref } from "./href";
-import { useLink } from "./useLink";
 import useLinkToPathProps from "./useLinkToPathProps";
+import { useRouter } from "./useRouter";
 
 type Props = {
   /** Add a property which is familiar to  */
@@ -28,9 +28,9 @@ type Props = {
 
 /** Redirects to the href as soon as the component is mounted. */
 export function Redirect({ href }: { href: Href }) {
-  const link = useLink();
+  const router = useRouter();
   useFocusEffect(() => {
-    link.replace(href);
+    router.replace(href);
   });
   return null;
 }

--- a/packages/expo-router/src/link/href.ts
+++ b/packages/expo-router/src/link/href.ts
@@ -5,8 +5,6 @@ export type HrefObject = {
   pathname?: string;
   /** Query parameters for the path. */
   params?: Record<string, any>;
-  /** @deprecated use `params` instead. */
-  query?: Record<string, any>;
 };
 
 /** Resolve an href object into a fully qualified, relative href. */

--- a/packages/expo-router/src/link/useHref.ts
+++ b/packages/expo-router/src/link/useHref.ts
@@ -1,128 +1,21 @@
-import * as queryString from "query-string";
-import React from "react";
-
-import { RootContainer } from "../ContextNavigationContainer";
-import getPathFromState, { State } from "../fork/getPathFromState";
-import { useInitialRootStateContext } from "../rootStateContext";
+import { usePathname, useSearchParams, useSegments } from "../LocationProvider";
 import { HrefObject } from "./href";
-import { useLinkingContext } from "./useLinkingContext";
 
+/** @deprecated */
 type RouteInfo = Omit<Required<HrefObject>, "query"> & {
   /** Normalized path representing the selected route `/[id]?id=normal` -> `/normal` */
   href: string;
 };
 
-function getRouteInfoFromState(
-  getPathFromState: (state: State, asPath: boolean) => string,
-  state: State
-): RouteInfo {
-  return {
-    href: getPathFromState(state, false),
-    ...getNormalizedStatePath(getPathFromState(state, true)),
-  };
-}
-
-function compareShallowRecords(a: Record<string, any>, b: Record<string, any>) {
-  const aKeys = Object.keys(a);
-  const bKeys = Object.keys(b);
-
-  if (aKeys.length !== bKeys.length) {
-    return false;
-  }
-
-  for (const key of aKeys) {
-    if (a[key] !== b[key]) {
-      return false;
-    }
-  }
-
-  return true;
-}
-
-function compareRouteInfo(a: RouteInfo, b: RouteInfo) {
-  return (
-    a.href === b.href &&
-    a.pathname === b.pathname &&
-    compareShallowRecords(a.params, b.params)
-  );
-}
-
+/** @deprecated */
 export function useHref(): RouteInfo {
-  const initialRootState = useInitialRootStateContext();
-  const getPathFromState = useGetPathFromState();
-
-  const [routeInfo, setRouteInfo] = React.useState<RouteInfo>(
-    getRouteInfoFromState(
-      getPathFromState,
-      // If the root state (from upstream) is not ready, use the hacky initial state.
-      // Initial state can be generate because it assumes the linking configuration never changes.
-      RootContainer.getRef().getRootState() ?? initialRootState
-    )
+  console.warn(
+    "useHref is deprecated in favor of usePathname, useSearchParams, and useSegments"
   );
-
-  const routeInfoRef = React.useRef(routeInfo);
-
-  React.useEffect(() => {
-    routeInfoRef.current = routeInfo;
-  }, [routeInfo]);
-
-  const maybeUpdateRouteInfo = React.useCallback(
-    (state: State) => {
-      // Prevent unnecessary updates
-      const newRouteInfo = getRouteInfoFromState(getPathFromState, state);
-      if (!compareRouteInfo(routeInfoRef.current, newRouteInfo)) {
-        setRouteInfo(newRouteInfo);
-      }
-    },
-    [
-      // TODO: This probably never changes
-      getPathFromState,
-    ]
-  );
-
-  React.useEffect(() => {
-    const rootNavigation = RootContainer.getRef();
-
-    return rootNavigation.addListener("state", ({ data }) => {
-      // Attempt to use the complete state from the root, otherwise this will default to
-      // sending events from the nearest layout.
-      const navigationState =
-        rootNavigation.getRootState() ?? (data.state as unknown as State);
-      // NOTE(EvanBacon): It's probably worth asserting if the root state is missing here.
-      maybeUpdateRouteInfo(navigationState);
-    });
-  }, [maybeUpdateRouteInfo]);
-
-  return routeInfo;
-}
-
-export function useGetPathFromState() {
-  const linking = useLinkingContext();
-
-  return React.useCallback(
-    (state: Parameters<typeof getPathFromState>[0], asPath: boolean) => {
-      return linking.getPathFromState(state, {
-        ...linking.config,
-        // @ts-expect-error
-        preserveDynamicRoutes: asPath,
-        preserveFragments: asPath,
-      });
-    },
-    [linking]
-  );
-}
-
-// TODO: Split up getPathFromState to return all this info at once.
-function getNormalizedStatePath(statePath: string): {
-  pathname: string;
-  params: queryString.ParsedQuery<string>;
-} {
-  const [pathname, querystring] = statePath.split("?");
 
   return {
-    pathname,
-    // TODO: This is not efficient, we should generate based on the state instead
-    // of converting to string then back to object
-    params: querystring ? queryString.parse(querystring) : {},
+    href: usePathname(),
+    pathname: useSegments().join("/"),
+    params: useSearchParams(),
   };
 }

--- a/packages/expo-router/src/link/useRouter.ts
+++ b/packages/expo-router/src/link/useRouter.ts
@@ -5,12 +5,21 @@ import { useLinkToPath } from "./useLinkToPath";
 import { useLoadedNavigation } from "./useLoadedNavigation";
 
 // Wraps useLinkTo to provide an API which is similar to the Link component.
-export function useLink(): {
+export function useLink() {
+  console.warn("`useLink()` is deprecated in favor of `useRouter()`");
+  return useRouter();
+}
+
+type Router = {
+  /** Navigate to the provided href. */
   push: (href: Href) => void;
+  /** Navigate to route without appending to the history. */
   replace: (href: Href) => void;
+  /** Go back in the history. */
   back: () => void;
-  parse: typeof resolveHref;
-} {
+};
+
+export function useRouter(): Router {
   const pending = useLoadedNavigation();
   const linkTo = useLinkToPath();
 
@@ -33,7 +42,6 @@ export function useLink(): {
     push,
     back,
     replace,
-    parse: resolveHref,
     // TODO(EvanBacon): add `reload`
     // TODO(EvanBacon): add `canGoBack` but maybe more like a `hasContext`
   };

--- a/packages/expo-router/src/views/Unmatched.tsx
+++ b/packages/expo-router/src/views/Unmatched.tsx
@@ -2,15 +2,15 @@ import { StyleSheet, Text, View } from "@bacons/react-views";
 import { createURL } from "expo-linking";
 import React, { forwardRef } from "react";
 
+import { usePathname } from "../LocationProvider";
 import { Link } from "../link/Link";
-import { useHref } from "../link/useHref";
 import { useNavigation } from "../useNavigation";
 
 /** Default screen for unmatched routes. */
 export const Unmatched = forwardRef((props, ref) => {
   const navigation = useNavigation();
-  const href = useHref();
-  const url = createURL(href.href);
+  const pathname = usePathname();
+  const url = createURL(pathname);
 
   React.useLayoutEffect(() => {
     navigation.setOptions({
@@ -39,7 +39,7 @@ export const Unmatched = forwardRef((props, ref) => {
         </Link>
       </Text>
 
-      <Link href={href.href} replace style={styles.link}>
+      <Link href={pathname} replace style={styles.link}>
         {url}
       </Link>
 


### PR DESCRIPTION
# Motivation

Many of the larger issues in Expo Router are related to React Navigation APIs that we don't have a good answer for yet. This is the first of a couple PRs which will attempt to rethink the native aspects of Expo Router to be a bit more web-first.

These changes will be merged into a v2 beta branch and published accordingly.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# Execution

- Create a shared global context for defining the URL resolution once.
- Split `useHref` into three different hooks `usePathname`, `useSearchParams`, `useSegments`. 
   - `href` -> `usePathname`
   - `pathname` -> `useSegments` (now returns an array of `string`s containing the conventional segments)
   - `params` -> `useSearchParams` (now returns a `URLSearchParams` object).
- Move docs mentions of React Navigation from Linking to the migration guide. Consider it secondary to the core API.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
