### PR TITLE
[docs] Fix modals guide code snippet

### DIFF
--- a/docs/docs/guides/modals.md
+++ b/docs/docs/guides/modals.md
@@ -74,7 +74,7 @@ export default function Modal({ navigation }) {
       {!isPresented && <Link href="../">Dismiss</Link>}
 
       {/* Native modals have dark backgrounds on iOS, set the status bar to light content. */}
-      <StatusBar barStyle="light-content" />
+      <StatusBar style="light" />
     </View>
   );
 }


### PR DESCRIPTION
# Motivation

`StatusBar` from `expo-status-bar` does not support the `barStyle` prop

# Execution

Updates Modals guide code snippet to use `style="light"` instead 

 
