### PR TITLE
Ensure navigation loads before redirecting

### DIFF
--- a/apps/demo/app/(app)/_layout.tsx
+++ b/apps/demo/app/(app)/_layout.tsx
@@ -7,6 +7,7 @@ export default function RootLayout() {
         headerShown: false,
       }}
     >
+      <Tabs.Screen name="index" options={{ href: null }} />
       <Tabs.Screen name="(feed)" options={{ title: "Home" }} />
       <Tabs.Screen name="(explore)" options={{ title: "Search" }} />
       <Tabs.Screen

--- a/apps/demo/app/(app)/index.tsx
+++ b/apps/demo/app/(app)/index.tsx
@@ -1,0 +1,5 @@
+import { Redirect } from "expo-router";
+
+export default function Index() {
+  return <Redirect href="/explore" />;
+}

--- a/packages/expo-router/src/exports.ts
+++ b/packages/expo-router/src/exports.ts
@@ -19,4 +19,4 @@ export * as Linking from "./link/linking";
 // React Navigation
 export { useNavigation } from "./useNavigation";
 export { RootContainer } from "./ContextNavigationContainer";
-export { useFocusEffect } from "@react-navigation/native";
+export { useFocusEffect } from "./useFocusEffect";

--- a/packages/expo-router/src/link/Link.tsx
+++ b/packages/expo-router/src/link/Link.tsx
@@ -2,10 +2,10 @@
 // `to` / `action` support removed.
 import { Text, TextProps } from "@bacons/react-views";
 import { Slot } from "@radix-ui/react-slot";
-import { useFocusEffect } from "@react-navigation/native";
 import * as React from "react";
 import { GestureResponderEvent, Platform } from "react-native";
 
+import { useFocusEffect } from "../useFocusEffect";
 import { Href, resolveHref } from "./href";
 import useLinkToPathProps from "./useLinkToPathProps";
 import { useRouter } from "./useRouter";

--- a/packages/expo-router/src/link/useLoadedNavigation.ts
+++ b/packages/expo-router/src/link/useLoadedNavigation.ts
@@ -1,5 +1,5 @@
 import { NavigationProp, useNavigation } from "@react-navigation/native";
-import { useCallback, useEffect, useRef } from "react";
+import { useCallback, useState, useEffect, useRef } from "react";
 
 import { RootContainer } from "../ContextNavigationContainer";
 
@@ -46,4 +46,15 @@ export function useLoadedNavigation() {
   );
 
   return push;
+}
+
+export function useOptionalNavigation(): GenericNavigation | null {
+  const [navigation, setNavigation] = useState<GenericNavigation | null>(null);
+  const loadNavigation = useLoadedNavigation();
+
+  useEffect(() => {
+    loadNavigation((nav) => setNavigation(nav));
+  }, []);
+
+  return navigation;
 }

--- a/packages/expo-router/src/useFocusEffect.tsx
+++ b/packages/expo-router/src/useFocusEffect.tsx
@@ -1,6 +1,5 @@
 // A fork of `useFocusEffect` that waits for the navigation state to load before
 // running the effect. This is especially useful for native redirects.
-import { NavigationProp } from "@react-navigation/native";
 import * as React from "react";
 
 import { useOptionalNavigation } from "./link/useLoadedNavigation";
@@ -14,10 +13,13 @@ type EffectCallback = () => undefined | void | (() => void);
  *
  * @param callback Memoized callback containing the effect, should optionally return a cleanup function.
  */
-export function useFocusEffect(effect: EffectCallback) {
+export function useFocusEffect(
+  effect: EffectCallback,
+  do_not_pass_a_second_prop?: any
+) {
   const navigation = useOptionalNavigation();
 
-  if (arguments[1] !== undefined) {
+  if (do_not_pass_a_second_prop !== undefined) {
     const message =
       "You passed a second argument to 'useFocusEffect', but it only accepts one argument. " +
       "If you want to pass a dependency array, you can use 'React.useCallback':\n\n" +

--- a/packages/expo-router/src/useFocusEffect.tsx
+++ b/packages/expo-router/src/useFocusEffect.tsx
@@ -1,0 +1,119 @@
+// A fork of `useFocusEffect` that waits for the navigation state to load before
+// running the effect. This is especially useful for native redirects.
+import { NavigationProp } from "@react-navigation/native";
+import * as React from "react";
+
+import { useOptionalNavigation } from "./link/useLoadedNavigation";
+
+type EffectCallback = () => undefined | void | (() => void);
+
+/**
+ * Hook to run an effect in a focused screen, similar to `React.useEffect`.
+ * This can be used to perform side-effects such as fetching data or subscribing to events.
+ * The passed callback should be wrapped in `React.useCallback` to avoid running the effect too often.
+ *
+ * @param callback Memoized callback containing the effect, should optionally return a cleanup function.
+ */
+export function useFocusEffect(effect: EffectCallback) {
+  const navigation = useOptionalNavigation();
+
+  if (arguments[1] !== undefined) {
+    const message =
+      "You passed a second argument to 'useFocusEffect', but it only accepts one argument. " +
+      "If you want to pass a dependency array, you can use 'React.useCallback':\n\n" +
+      "useFocusEffect(\n" +
+      "  React.useCallback(() => {\n" +
+      "    // Your code here\n" +
+      "  }, [depA, depB])\n" +
+      ");\n\n" +
+      "See usage guide: https://reactnavigation.org/docs/use-focus-effect";
+
+    console.error(message);
+  }
+
+  React.useEffect(() => {
+    if (!navigation) {
+      return;
+    }
+
+    let isFocused = false;
+    let cleanup: undefined | void | (() => void);
+
+    const callback = () => {
+      const destroy = effect();
+
+      if (destroy === undefined || typeof destroy === "function") {
+        return destroy;
+      }
+
+      if (process.env.NODE_ENV !== "production") {
+        let message =
+          "An effect function must not return anything besides a function, which is used for clean-up.";
+
+        if (destroy === null) {
+          message +=
+            " You returned 'null'. If your effect does not require clean-up, return 'undefined' (or nothing).";
+        } else if (typeof (destroy as any).then === "function") {
+          message +=
+            "\n\nIt looks like you wrote 'useFocusEffect(async () => ...)' or returned a Promise. " +
+            "Instead, write the async function inside your effect " +
+            "and call it immediately:\n\n" +
+            "useFocusEffect(\n" +
+            "  React.useCallback(() => {\n" +
+            "    async function fetchData() {\n" +
+            "      // You can await here\n" +
+            "      const response = await MyAPI.getData(someId);\n" +
+            "      // ...\n" +
+            "    }\n\n" +
+            "    fetchData();\n" +
+            "  }, [someId])\n" +
+            ");\n\n" +
+            "See usage guide: https://reactnavigation.org/docs/use-focus-effect";
+        } else {
+          message += ` You returned '${JSON.stringify(destroy)}'.`;
+        }
+
+        console.error(message);
+      }
+    };
+
+    // We need to run the effect on intial render/dep changes if the screen is focused
+    if (navigation.isFocused()) {
+      cleanup = callback();
+      isFocused = true;
+    }
+
+    const unsubscribeFocus = navigation.addListener("focus", () => {
+      // If callback was already called for focus, avoid calling it again
+      // The focus event may also fire on intial render, so we guard against runing the effect twice
+      if (isFocused) {
+        return;
+      }
+
+      if (cleanup !== undefined) {
+        cleanup();
+      }
+
+      cleanup = callback();
+      isFocused = true;
+    });
+
+    const unsubscribeBlur = navigation.addListener("blur", () => {
+      if (cleanup !== undefined) {
+        cleanup();
+      }
+
+      cleanup = undefined;
+      isFocused = false;
+    });
+
+    return () => {
+      if (cleanup !== undefined) {
+        cleanup();
+      }
+
+      unsubscribeFocus();
+      unsubscribeBlur();
+    };
+  }, [effect, navigation]);
+}


### PR DESCRIPTION
# Motivation

- The "navigation hasn't loaded" error is very upsetting.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# Execution

- Create a forked `useLayoutEffect` which waits for the navigation object to load.


# Test Plan

`app/index` -> `<Redirect href="/other"/>` will not assert navigation not loaded