### PR TITLE
fix root level initial route name

### DIFF
--- a/packages/expo-router/src/fork/getStateFromPath.ts
+++ b/packages/expo-router/src/fork/getStateFromPath.ts
@@ -101,6 +101,13 @@ export default function getStateFromPath<ParamList extends object>(
   // This will be mutated...
   const initialRoutes: InitialRouteConfig[] = [];
 
+  if (options?.initialRouteName) {
+    initialRoutes.push({
+      initialRouteName: options.initialRouteName,
+      parentScreens: [],
+    });
+  }
+
   // Create a normalized configs array which will be easier to use.
   const converted = Object.keys(screens)
     .map((key) => createNormalizedConfigs(key, screens, [], initialRoutes))

--- a/packages/expo-router/src/getLinkingConfig.ts
+++ b/packages/expo-router/src/getLinkingConfig.ts
@@ -91,6 +91,8 @@ export function getLinkingConfig(routes: RouteNode): LinkingOptions<object> {
       ...getAllWebRedirects(),
     ],
     config: {
+      // @ts-expect-error
+      initialRouteName: routes.initialRouteName,
       screens: getReactNavigationScreensConfig(routes.children),
     },
     // A custom getInitialURL is used on native to ensure the app always starts at

--- a/packages/expo-router/src/getRoutes.ts
+++ b/packages/expo-router/src/getRoutes.ts
@@ -129,27 +129,29 @@ function getDefaultInitialRoute(node: RouteNode, name: string) {
 
 function applyDefaultInitialRouteName(node: RouteNode): RouteNode {
   const groupName = matchGroupName(node.route);
-  if (!node.children || !groupName) {
+  if (!node.children?.length) {
     return node;
   }
 
   // Guess at the initial route based on the group name.
   // TODO(EvanBacon): Perhaps we should attempt to warn when the group doesn't match any child routes.
-  let initialRouteName = getDefaultInitialRoute(node, groupName)?.route;
+  let initialRouteName = groupName
+    ? getDefaultInitialRoute(node, groupName)?.route
+    : undefined;
   const loaded = node.loadRoute();
 
   if (loaded.unstable_settings) {
-    // Allow unstable_settings={ 'custom': { initialRouteName: '...' } } to override the less specific initial route name.
-    const groupSpecificInitialRouteName =
-      loaded.unstable_settings?.[groupName]?.initialRouteName;
-
     // Allow unstable_settings={ initialRouteName: '...' } to override the default initial route name.
-    const definedInitialRouteName = loaded.unstable_settings.initialRouteName;
-
     initialRouteName =
-      groupSpecificInitialRouteName ??
-      definedInitialRouteName ??
-      initialRouteName;
+      loaded.unstable_settings.initialRouteName ?? initialRouteName;
+
+    if (groupName) {
+      // Allow unstable_settings={ 'custom': { initialRouteName: '...' } } to override the less specific initial route name.
+      const groupSpecificInitialRouteName =
+        loaded.unstable_settings?.[groupName]?.initialRouteName;
+
+      initialRouteName = groupSpecificInitialRouteName ?? initialRouteName;
+    }
   }
 
   return {


### PR DESCRIPTION
# Motivation

Found some issues when attempting to create a simple blog with Expo Router.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# Execution

- Allow initialRouteName for non-group directories.
- Allow initialRouteName for `app/_layout.js` (root-level).

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

```
app
  _layout.js -> unstable_settings (index as root) / Stack
  index.js
  other.js
```

reloading from `/other` should have a back arrow.