### PR TITLE
Rename the Layout and Children components

### DIFF
--- a/packages/expo-router/src/exports.ts
+++ b/packages/expo-router/src/exports.ts
@@ -1,10 +1,12 @@
 // Expo Router API
+import { Navigator, Slot } from "./views/Layout";
+
 export { useRouter } from "./link/useRouter";
 export { usePathname, useSearchParams, useSegments } from "./LocationProvider";
 export { Link, Redirect } from "./link/Link";
 
 export { withLayoutContext } from "./layouts/withLayoutContext";
-export { Layout, Children } from "./views/Layout";
+export { Navigator, Slot };
 
 // Expo Router Views
 export { ExpoRoot } from "./views/Root";
@@ -20,3 +22,10 @@ export * as Linking from "./link/linking";
 export { useNavigation } from "./useNavigation";
 export { RootContainer } from "./ContextNavigationContainer";
 export { useFocusEffect } from "./useFocusEffect";
+
+// Deprecated (doesn't matter in beta)
+
+/** @deprecated use `<Navigator />` */
+export const Layout = Navigator;
+/** @deprecated use `<Slot />` */
+export const Children = Slot;

--- a/packages/expo-router/src/getRoutes.ts
+++ b/packages/expo-router/src/getRoutes.ts
@@ -7,7 +7,7 @@ import {
   stripGroupSegmentsFromPath,
 } from "./matchers";
 import { RequireContext } from "./types";
-import { DefaultLayout } from "./views/Layout";
+import { DefaultNavigator } from "./views/Layout";
 
 export type FileNode = Pick<RouteNode, "contextKey" | "loadRoute"> & {
   /** Like `(tab)/index` */
@@ -299,7 +299,7 @@ function treeNodesToRootRoute(treeNode: TreeNode): RouteNode | null {
   }
 
   return {
-    loadRoute: () => ({ default: DefaultLayout }),
+    loadRoute: () => ({ default: DefaultNavigator }),
     // Generate a fake file name for the directory
     contextKey: "./_layout.tsx",
     route: "",


### PR DESCRIPTION
# Motivation

- `Layout` -> `Navigator`: Most `_layout` files export a function named `Layout` — this can lead to a recursive loop if they accidentally export `Layout` from `Layout`.
- `Children` -> `Slot`: `Children` is a React TS export and sometimes auto import picks it instead of Expo Router. Also, it’s not rendering children, it’s rendering the selected child. `Slot` is used in other web frameworks like SvelteKit and Remix so it would seem familiar to some devs.

