### PR TITLE
drop logging, export useRootNavigation, useRootNavigationState

### DIFF
--- a/apps/sandbox/app/index.tsx
+++ b/apps/sandbox/app/index.tsx
@@ -1,0 +1,34 @@
+import { StyleSheet, Text, View } from "react-native";
+
+export default function Page() {
+  return (
+    <View style={styles.container}>
+      <View style={styles.main}>
+        <Text style={styles.title}>Hello World</Text>
+        <Text style={styles.subtitle}>This is the first page of your app.</Text>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: "center",
+    padding: 24,
+  },
+  main: {
+    flex: 1,
+    justifyContent: "center",
+    maxWidth: 960,
+    marginHorizontal: "auto",
+  },
+  title: {
+    fontSize: 64,
+    fontWeight: "bold",
+  },
+  subtitle: {
+    fontSize: 36,
+    color: "#38434D",
+  },
+});

--- a/docs/docs/migration/react-navigation/navigation-container.md
+++ b/docs/docs/migration/react-navigation/navigation-container.md
@@ -36,9 +36,7 @@ function Example() {
 
 #### `getRootState`
 
-> TODO: Replace this with a standalone hook
-
-Use `RootContainer.useState()`
+Use `useRootNavigationState()`.
 
 #### `getCurrentRoute`
 
@@ -121,4 +119,4 @@ This property is not yet supported in Expo Router. Set the web page title using 
 
 <!-- TODO: Replace this with something like `useNavigation('...')` -->
 
-Use the `RootContainer.useRef()` function instead.
+Use the `useRootNavigation()` hook instead.

--- a/packages/expo-router/src/ContextNavigationContainer.tsx
+++ b/packages/expo-router/src/ContextNavigationContainer.tsx
@@ -61,14 +61,8 @@ function InternalContextNavigationContainer() {
   const [contextProps] = useNavigationContainerContext();
   const [isReady, setReady] = React.useState(false);
   const ref = React.useMemo(() => (isReady ? navigationRef : null), [isReady]);
-
   const root = useRootRouteNodeContext();
-
-  const linking = React.useMemo(() => {
-    const linking = getLinkingConfig(root);
-    console.log("linking", linking);
-    return linking;
-  }, [root]);
+  const linking = React.useMemo(() => getLinkingConfig(root), [root]);
 
   React.useEffect(() => {
     contextProps.onReady?.();

--- a/packages/expo-router/src/exports.ts
+++ b/packages/expo-router/src/exports.ts
@@ -20,7 +20,7 @@ export * as Linking from "./link/linking";
 
 // React Navigation
 export { useNavigation } from "./useNavigation";
-export { RootContainer } from "./ContextNavigationContainer";
+export { useRootNavigation, useRootNavigationState } from "./useRootNavigation";
 export { useFocusEffect } from "./useFocusEffect";
 
 // Deprecated (doesn't matter in beta)


### PR DESCRIPTION
# Motivation

- Drop the linking log.
- Drop the `RootContainer` component.
- Export `useRootNavigation` and `useRootNavigationState` hooks.
