### PR TITLE
feat: add support of platform specific routes and layouts

### DIFF
--- a/packages/expo-router/src/__tests__/getRoutes.test.node.ts
+++ b/packages/expo-router/src/__tests__/getRoutes.test.node.ts
@@ -426,4 +426,36 @@ describe(getRoutes, () => {
   it(`should convert an empty context module to routes`, () => {
     expect(getRoutes(createMockContextModule({}))).toEqual(null);
   });
+
+  it(`get platform specific routes`, () => {
+    expect(
+      dropFunctions(
+        getRoutes(
+          createMockContextModule({
+            "./_layout.tsx": { default() {} },
+            "./_layout.ios.tsx": { default() {} },
+            "./user.tsx": { default() {} },
+            "./user.web.tsx": { default() {} },
+            "./user.ios.tsx": { default() {} },
+          })
+        )!
+      )
+    ).toEqual(
+      expect.objectContaining({
+        children: [
+          {
+            children: [],
+            contextKey: "./user.ios.tsx",
+            dynamic: null,
+            route: "user",
+          },
+          ROUTE_DIRECTORY,
+          ROUTE_404,
+        ],
+        contextKey: "./_layout.ios.tsx",
+        dynamic: null,
+        route: "",
+      })
+    );
+  });
 });

--- a/packages/expo-router/src/matchers.tsx
+++ b/packages/expo-router/src/matchers.tsx
@@ -19,6 +19,11 @@ export function getNameFromFilePath(name: string): string {
   return removeSupportedExtensions(removeFileSystemDots(name));
 }
 
+/** Check if name ends with .ios, .android, .web ... */
+export function matchPlatformSpecific(name: string): boolean {
+  return /\.[a-z]+$/.test(name);
+}
+
 /** Remove `.js`, `.ts`, `.jsx`, `.tsx` */
 function removeSupportedExtensions(name: string): string {
   return name.replace(/\.[jt]sx?$/g, "");


### PR DESCRIPTION
# Motivation

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->
The goal is to add support of platform specific layout / routes.

for example, `_layout.web.tsx` overrides `_layout.tsx` on web platform, `[user].ios.tsx` overrides `[user].tsx` on iOS platform

# Execution

<!--
How did you build this feature or fix this bug and why?
-->

I needed this feature to add distinct layout context according to platform (web vs native) and I would like in the future to add platform specific routes 

# Test Plan
I have added a test see `router/packages/expo-router/src/__tests__/getRoutes.test.node.ts` 

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Build an app (I have mostly tested on web) and check that adding a route (or a layout) containing platform extension overrides default one