### PR TITLE
delay splash screen hiding for one cycle

### DIFF
--- a/packages/expo-router/src/ContextNavigationContainer.tsx
+++ b/packages/expo-router/src/ContextNavigationContainer.tsx
@@ -60,6 +60,7 @@ export function ContextNavigationContainer(props: NavigationContainerProps) {
 function InternalContextNavigationContainer() {
   const [contextProps] = useNavigationContainerContext();
   const [isReady, setReady] = React.useState(false);
+  const [isSplashReady, setSplashReady] = React.useState(false);
   const ref = React.useMemo(() => (isReady ? navigationRef : null), [isReady]);
   const root = useRootRouteNodeContext();
   const linking = React.useMemo(() => getLinkingConfig(root), [root]);
@@ -70,17 +71,18 @@ function InternalContextNavigationContainer() {
 
   return (
     <RootNavigationRef.Provider value={{ ref }}>
-      {!isReady && <SplashScreen />}
+      {!isSplashReady && <SplashScreen />}
       {/* @ts-expect-error: children are required */}
       <NavigationContainer
         {...contextProps}
         linking={linking}
         ref={navigationRef}
         onReady={() => {
+          setReady(true);
           // Allow one cycle for the children to mount a splash screen
           // that will prevent the splash screen from hiding.
           requestAnimationFrame(() => {
-            setReady(true);
+            setSplashReady(true);
           });
         }}
       />

--- a/packages/expo-router/src/ContextNavigationContainer.tsx
+++ b/packages/expo-router/src/ContextNavigationContainer.tsx
@@ -77,7 +77,11 @@ function InternalContextNavigationContainer() {
         linking={linking}
         ref={navigationRef}
         onReady={() => {
-          setReady(true);
+          // Allow one cycle for the children to mount a splash screen
+          // that will prevent the splash screen from hiding.
+          requestAnimationFrame(() => {
+            setReady(true);
+          });
         }}
       />
     </RootNavigationRef.Provider>

--- a/packages/expo-router/src/layouts/Tabs.tsx
+++ b/packages/expo-router/src/layouts/Tabs.tsx
@@ -6,9 +6,9 @@ import {
 import React from "react";
 import { Platform } from "react-native";
 
+import { withLayoutContext } from "./withLayoutContext";
 import { Link } from "../link/Link";
 import { Href } from "../link/href";
-import { withLayoutContext } from "./withLayoutContext";
 
 // This is the only way to access the navigator.
 const BottomTabNavigator = createBottomTabNavigator().Navigator;

--- a/packages/expo-router/src/link/Link.tsx
+++ b/packages/expo-router/src/link/Link.tsx
@@ -5,10 +5,10 @@ import { Slot } from "@radix-ui/react-slot";
 import * as React from "react";
 import { GestureResponderEvent, Platform } from "react-native";
 
-import { useFocusEffect } from "../useFocusEffect";
 import { Href, resolveHref } from "./href";
 import useLinkToPathProps from "./useLinkToPathProps";
 import { useRouter } from "./useRouter";
+import { useFocusEffect } from "../useFocusEffect";
 
 type Props = {
   /** Path to route to. */

--- a/packages/expo-router/src/link/useHref.ts
+++ b/packages/expo-router/src/link/useHref.ts
@@ -1,5 +1,5 @@
-import { usePathname, useSearchParams, useSegments } from "../LocationProvider";
 import { HrefObject } from "./href";
+import { usePathname, useSearchParams, useSegments } from "../LocationProvider";
 
 /** @deprecated */
 type RouteInfo = Omit<Required<HrefObject>, "query"> & {

--- a/packages/expo-router/src/link/useLinkToPathProps.tsx
+++ b/packages/expo-router/src/link/useLinkToPathProps.tsx
@@ -1,8 +1,8 @@
 import * as React from "react";
 import { GestureResponderEvent, Platform } from "react-native";
 
-import { stripGroupSegmentsFromPath } from "../matchers";
 import { useLinkToPath } from "./useLinkToPath";
+import { stripGroupSegmentsFromPath } from "../matchers";
 
 export default function useLinkToPathProps(props: {
   href: string;

--- a/packages/expo-router/src/link/useRouter.ts
+++ b/packages/expo-router/src/link/useRouter.ts
@@ -1,9 +1,9 @@
 import { useCallback } from "react";
 
-import { RootContainer } from "../ContextNavigationContainer";
 import { Href, resolveHref } from "./href";
 import { useLinkToPath } from "./useLinkToPath";
 import { useLoadedNavigation } from "./useLoadedNavigation";
+import { RootContainer } from "../ContextNavigationContainer";
 
 // Wraps useLinkTo to provide an API which is similar to the Link component.
 export function useLink() {

--- a/packages/expo-router/src/views/ErrorBoundary.tsx
+++ b/packages/expo-router/src/views/ErrorBoundary.tsx
@@ -3,8 +3,8 @@ import React from "react";
 import { Platform, ScrollView, TouchableOpacity } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 
-import { Link } from "../link/Link";
 import { ErrorBoundaryProps } from "./Try";
+import { Link } from "../link/Link";
 
 export function ErrorBoundary({ error, retry }: ErrorBoundaryProps) {
   return (

--- a/packages/expo-router/src/views/Layout.tsx
+++ b/packages/expo-router/src/views/Layout.tsx
@@ -5,10 +5,10 @@ import {
 } from "@react-navigation/native";
 import * as React from "react";
 
+import { Screen } from "./Screen";
 import { useContextKey } from "../Route";
 import { useFilterScreenChildren } from "../layouts/withLayoutContext";
 import { useSortedScreens } from "../useScreens";
-import { Screen } from "./Screen";
 
 // TODO: This might already exist upstream, maybe something like `useCurrentRender` ?
 export const NavigatorContext = React.createContext<{

--- a/packages/expo-router/src/views/Splash.tsx
+++ b/packages/expo-router/src/views/Splash.tsx
@@ -66,7 +66,7 @@ SplashScreen.preventAutoHideAsync = () => {
   }
   _preventAutoHideAsyncInvoked = true;
   // Append error handling to ensure any uncaught exceptions result in the splash screen being hidden.
-  if (Platform.OS !== "web" && ErrorUtils && ErrorUtils.getGlobalHandler) {
+  if (Platform.OS !== "web" && ErrorUtils?.getGlobalHandler) {
     const originalHandler = ErrorUtils.getGlobalHandler();
     ErrorUtils.setGlobalHandler((error, isFatal) => {
       SplashScreen.hideAsync();


### PR DESCRIPTION
# Motivation


- fix https://github.com/expo/router/issues/212
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# Execution

Allow one cycle for splash screen to be delayed by children components before unmounting.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
