### PR TITLE
skip attempting to parse undefined state

### DIFF
--- a/packages/expo-router/src/LocationProvider.tsx
+++ b/packages/expo-router/src/LocationProvider.tsx
@@ -69,6 +69,10 @@ function useUrlObject(): UrlObject {
 
   const maybeUpdateRouteInfo = React.useCallback(
     (state: State) => {
+      // The state can be undefined when hot reloading a Layout Route on native.
+      if (!state) {
+        return;
+      }
       // Prevent unnecessary updates
       const newRouteInfo = getRouteInfoFromState(getPathFromState, state);
       if (!compareRouteInfo(routeInfoRef.current, newRouteInfo)) {


### PR DESCRIPTION
# Motivation

The state will emit an undefined object when hot reloading a Layout Route on iOS. Resulting in:

```
Error: Got 'undefined' for the navigation state. You must pass a valid state object.

This error is located at:
    in BaseNavigationContainer
    in ThemeProvider
    in NavigationContainerInner (created by InternalContextNavigationContainer)
    in InternalContextNavigationContainer (created by ContextNavigationContainer)
    in ContextNavigationContainer (created by ContextNavigator)
    in RootRouteNodeProvider (created by ContextNavigator)
    in ContextNavigator (created by ExpoRoot)
    in RNCSafeAreaProvider (created by SafeAreaProvider)
    in SafeAreaProvider (created by ExpoRoot)
    in RCTView (created by View)
    in View (created by GestureHandlerRootView)
    in GestureHandlerRootView (created by GestureHandler)
    in GestureHandler (created by ExpoRoot)
    in ExpoRoot (created by App)
    in App (created by ErrorOverlay)
    in ErrorToastContainer (created by ErrorOverlay)
    in ErrorOverlay (created by withDevTools(ErrorOverlay))
    in withDevTools(ErrorOverlay)
    in RCTView (created by View)
    in View (created by AppContainer)
    in RCTView (created by View)
    in View (created by AppContainer)
    in AppContainer
    in main(RootComponent), js engine: hermes
```

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# Execution

- Skip undefined state updates.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
