### PR TITLE
update useRouter back function documentation

### DIFF
--- a/docs/docs/features/linking.md
+++ b/docs/docs/features/linking.md
@@ -73,7 +73,7 @@ export default function Page() {
 
 - **push**: _`(href: Href) => void`_ Navigate to a route. You can provide a full path like `/profile/settings` or a relative path like `../settings`. Navigate to dynamic routes by passing an object like `{ pathname: 'profile', params: { id: '123' } }`.
 - **replace**: _`(href: Href) => void`_ Same API as `push` but replaces the current route in the history instead of pushing a new one. This is useful for redirects.
-- **back**: _`() => void`_ Navigate to a route. You can provide a full path like `/profile/settings` or a relative path like `../settings`. Navigate to dynamic routes by passing an object like `{ pathname: 'profile', params: { id: '123' } }`.
+- **back**: _`() => void`_ Navigate back to previous route.
 - **setParams**: _`(params: Record<string, string>) => void`_ Update the query params for the currently selected route.
 
 ### `Href` type


### PR DESCRIPTION
# Motivation

Found error in back function description when looking for a `popToTop` solution. Thought i could pass params to back function until i realised it was a copy paste error from  `push` description

# Execution

I updated the back function text description.

# Test Plan

Read commit and see previous and updated back function description text
