### PR TITLE
update drawer navigation docs

### DIFF
--- a/docs/docs/migration/react-navigation/drawer-navigator.md
+++ b/docs/docs/migration/react-navigation/drawer-navigator.md
@@ -43,3 +43,30 @@ export default function RootLayout() {
   return <Drawer />;
 }
 ```
+
+To edit the drawer navigation menu labels, titles and screen options specific screens are required as follows:
+
+```js title=app/_layout.js
+import { Drawer } from "../Drawer";
+
+export default function RootLayout() {
+  return (
+    <Drawer>
+      <Drawer.Screen
+        name="index" // This is the name of the page and must match the url from root
+        options={{
+          drawerLabel: 'Home',
+          title: 'overview',
+        }} 
+      />
+      <Drawer.Screen
+        name="user/[id]" // This is the name of the page and must match the url from root
+        options={{
+          drawerLabel: 'User',
+          title: 'overview',
+        }} 
+      />
+    </Drawer>
+  )
+}
+```


### PR DESCRIPTION
To figure out how to customise the navigation drawer labels I had to read through the source code to figure out where these options went.

It wasn't clear if expo-router had some specific config to customise these or I had to explicitly add screens, and this seemed like the only option.

If there is a better way please let me know and I will update this doc!

# Motivation

To help people understand how to edit the navigation drawer titles that are assigned to screens.

# Execution

Added more in depth documentation

# Test Plan

N/A
