### PR TITLE
Fix [typo] filename in Nesting Navigators Page in Doc

### DIFF
--- a/docs/docs/guides/nesting-navigators.md
+++ b/docs/docs/guides/nesting-navigators.md
@@ -37,7 +37,7 @@ export default function Root() {
 }
 ```
 
-This is nested in the `home.js` layout, so it will be rendered as a tab.
+This is nested in the `home/_layout.js` layout, so it will be rendered as a tab.
 
 ```js title=app/home/feed.js
 import { View, Text } from "react-native";


### PR DESCRIPTION
# Motivation

Fix typo `home.js` -> `home/_layout.js` on this [page](https://expo.github.io/router/docs/guides/nesting-navigators) in documentation. There is no `home.js` file.

# Execution
NA

# Test Plan
NA