### PR TITLE
drop build folder

### DIFF
--- a/packages/expo-router/_root.d.ts
+++ b/packages/expo-router/_root.d.ts
@@ -1,6 +1,0 @@
-export default function ExpoRouterRoot(): React.ReactElement;
-
-export function getManifest(): {
-  initialRouteName?: string | undefined;
-  screens: Record<string, Screen>;
-} | null;

--- a/packages/expo-router/_root.tsx
+++ b/packages/expo-router/_root.tsx
@@ -1,10 +1,12 @@
 import "@expo/metro-runtime";
+import React from "react";
 
 import { ExpoRoot } from "expo-router";
 
-import { getNavigationConfig } from "./build/getLinkingConfig";
-import { getRoutes } from "./build/getRoutes";
+import { getNavigationConfig } from "./src/getLinkingConfig";
+import { getRoutes } from "./src/getRoutes";
 
+// @ts-expect-error: Not sure
 const ctx = require.context(process.env.EXPO_ROUTER_APP_ROOT);
 
 // Must be exported or Fast Refresh won't update the context >:[

--- a/packages/expo-router/drawer.d.ts
+++ b/packages/expo-router/drawer.d.ts
@@ -1,2 +1,0 @@
-export * from "./build/layouts/Drawer";
-export { default } from "./build/layouts/Drawer";

--- a/packages/expo-router/drawer.js
+++ b/packages/expo-router/drawer.js
@@ -1,1 +1,0 @@
-module.exports = require("./build/layouts/Drawer");

--- a/packages/expo-router/drawer.ts
+++ b/packages/expo-router/drawer.ts
@@ -1,0 +1,2 @@
+export * from "./src/layouts/Drawer";
+export { default } from "./src/layouts/Drawer";

--- a/packages/expo-router/entry.js
+++ b/packages/expo-router/entry.js
@@ -3,7 +3,7 @@ import "@expo/metro-runtime";
 import { ExpoRoot } from "expo-router";
 import Head from "expo-router/head";
 
-import { renderRootComponent } from "./build/renderRootComponent";
+import { renderRootComponent } from "./src/renderRootComponent";
 
 // We add this elsewhere for rendering
 const HeadProvider =

--- a/packages/expo-router/head.d.ts
+++ b/packages/expo-router/head.d.ts
@@ -1,3 +1,0 @@
-import Head from "./build/head/Head";
-
-export default Head;

--- a/packages/expo-router/head.js
+++ b/packages/expo-router/head.js
@@ -1,1 +1,0 @@
-module.exports = require("./build/head/Head");

--- a/packages/expo-router/head.ts
+++ b/packages/expo-router/head.ts
@@ -1,0 +1,3 @@
+import Head from "./src/head/Head";
+
+export default Head;

--- a/packages/expo-router/node/render.js
+++ b/packages/expo-router/node/render.js
@@ -1,1 +1,2 @@
-module.exports = require("../build/static/renderStaticContent");
+// Assumes Metro handles this import.
+module.exports = require("../src/static/renderStaticContent");

--- a/packages/expo-router/package.json
+++ b/packages/expo-router/package.json
@@ -1,24 +1,19 @@
 {
   "name": "expo-router",
   "version": "1.0.0-rc7",
-  "main": "build/index.js",
+  "main": "src/index.tsx",
+  "types": "src/index.tsx",
   "files": [
+    "src",
+    "node",
     "entry.js",
-    "build",
+    "_root.tsx",
     "babel.js",
     "assets",
-    "drawer.js",
-    "drawer.d.ts",
-    "stack.js",
-    "stack.d.ts",
-    "tabs.js",
-    "tabs.d.ts",
-    "head.js",
-    "head.d.ts",
-    "node",
-    "_getRoutesManifest.js",
-    "_root.js",
-    "_root.d.ts"
+    "drawer.ts",
+    "stack.ts",
+    "tabs.ts",
+    "head.ts"
   ],
   "repository": {
     "url": "https://github.com/expo/router.git",
@@ -30,7 +25,7 @@
   },
   "homepage": "https://expo.github.io/router/docs/",
   "scripts": {
-    "build": "expo-module build",
+    "build": "expo-module typecheck",
     "clean": "expo-module clean",
     "lint": "expo-module lint",
     "test": "expo-module test",

--- a/packages/expo-router/stack.d.ts
+++ b/packages/expo-router/stack.d.ts
@@ -1,2 +1,0 @@
-export * from "./build/layouts/Stack";
-export { default } from "./build/layouts/Stack";

--- a/packages/expo-router/stack.js
+++ b/packages/expo-router/stack.js
@@ -1,1 +1,0 @@
-module.exports = require("./build/layouts/Stack");

--- a/packages/expo-router/stack.ts
+++ b/packages/expo-router/stack.ts
@@ -1,0 +1,2 @@
+export * from "./src/layouts/Stack";
+export { default } from "./src/layouts/Stack";

--- a/packages/expo-router/tabs.d.ts
+++ b/packages/expo-router/tabs.d.ts
@@ -1,2 +1,0 @@
-export * from "./build/layouts/Tabs";
-export { default } from "./build/layouts/Tabs";

--- a/packages/expo-router/tabs.js
+++ b/packages/expo-router/tabs.js
@@ -1,1 +1,0 @@
-module.exports = require("./build/layouts/Tabs");

--- a/packages/expo-router/tabs.ts
+++ b/packages/expo-router/tabs.ts
@@ -1,0 +1,2 @@
+export * from "./src/layouts/Tabs";
+export { default } from "./src/layouts/Tabs";

--- a/packages/expo-router/tsconfig.json
+++ b/packages/expo-router/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "expo-module-scripts/tsconfig.base",
   "compilerOptions": {
     "outDir": "./build",
+    "noEmit": true,
     "typeRoots": ["./ts-declarations", "../../node_modules/@types", "./node_modules/@types"],
     "types": [
       "jest",


### PR DESCRIPTION
# Motivation

- Experiment with shipping the source code as-is and utilizing Metro's cache for compilation. This will make it easier for users to modify the source to get unblocked while the package is still in early days.
