### PR TITLE
Fix/dynamic route pathname rerender

### DIFF
--- a/apps/sandbox/app_dynamicUsePathname/[...dynamic].tsx
+++ b/apps/sandbox/app_dynamicUsePathname/[...dynamic].tsx
@@ -1,0 +1,12 @@
+import { usePathname } from "expo-router";
+import { Text, View } from "react-native";
+export default function DynamicRoute() {
+  const pathname = usePathname()
+  console.log("rendered dynamic route");
+
+  return (
+    <View style={{ flex: 1, justifyContent: "center", alignItems: "center" }}>
+      <Text>Dynamic Route: {pathname}</Text>
+    </View>
+  );
+}

--- a/apps/sandbox/app_dynamicUsePathname/exact.tsx
+++ b/apps/sandbox/app_dynamicUsePathname/exact.tsx
@@ -1,0 +1,15 @@
+import { Link, usePathname } from "expo-router";
+import { Text, View } from "react-native";
+
+export default function ExactRoute() {
+  const pathname = usePathname()
+  console.log("rendered exact route");
+
+  return (
+    <View style={{ flex: 1, justifyContent: "center", alignItems: "center" }}>
+      <Text>Exact Route: {pathname}</Text>
+      <Link href="/">Go Home</Link>
+      <Link href="/random">Random</Link>
+    </View>
+  );
+}

--- a/apps/sandbox/app_dynamicUsePathname/index.tsx
+++ b/apps/sandbox/app_dynamicUsePathname/index.tsx
@@ -1,0 +1,26 @@
+import { Link, usePathname } from "expo-router";
+import { Text, View } from "react-native";
+
+export default function IndexRoute() {
+  const pathname = usePathname();
+  console.log("rendered index route");
+
+  return (
+    <View style={{ flex: 1, justifyContent: "center", alignItems: "center" }}>
+      <Text>Index Route: {pathname}</Text>
+      <Link style={styles} href="/exact">
+        Go to exact route
+      </Link>
+      <Link style={styles} href="/bamboleo">
+        Go to dynamic route
+      </Link>
+    </View>
+  );
+}
+
+const styles = {
+  marginVertical: 10,
+  padding: 10,
+  backgroundColor: "saddlebrown",
+  color: "white",
+};

--- a/packages/expo-router/src/LocationProvider.tsx
+++ b/packages/expo-router/src/LocationProvider.tsx
@@ -50,7 +50,13 @@ function compareUrlSearchParams(a: SearchParams, b: SearchParams): boolean {
     return false;
   }
 
-  return aKeys.every((key) => a[key] === b[key]);
+  return aKeys.every((key) => {
+    if (!aKeys.length) {
+      return a[key] === b[key];
+    } else {
+      return aKeys.every((paramKey) => aKeys[paramKey] === bKeys[paramKey]);
+    }
+  });
 }
 
 function useSafeInitialRootState() {
@@ -129,7 +135,6 @@ function useGetPathFromState() {
   return React.useCallback(
     (state: Parameters<typeof getPathFromState>[0], asPath: boolean) => {
       return getPathDataFromState(state, {
-        // return linking.getPathFromState(state, {
         ...linking.config,
         preserveDynamicRoutes: asPath,
         preserveGroups: asPath,


### PR DESCRIPTION
# Motivation

Fix: https://github.com/expo/router/issues/299

# Execution

Currently we are doing a [strict equality check](https://github.com/expo/router/blob/main/packages/expo-router/src/LocationProvider.tsx#L53) on `params` inside of `compareSearchParams`. However, `params` is an array when the route is dynamic, and therefore will always evaluate to `false` in this case.

When `compareSearchParams` evaluates to `false`, it makes `compareRouteInfo` also evaluate to `false`, which in turn means that we call `setRouteInfo()` and therefore [trigger an unnecessary rerender](https://github.com/expo/router/blob/main/packages/expo-router/src/LocationProvider.tsx#L101
). 

# Test Plan
Verified that in the demo app the dynamic route only renders once
