### PR TITLE
feat: add support for replacing across nested navigators

### DIFF
--- a/apps/demo/app/(app)/compose.tsx
+++ b/apps/demo/app/(app)/compose.tsx
@@ -1,15 +1,11 @@
 import { useRouter } from "expo-router";
 import { StatusBar } from "expo-status-bar";
 import React, { useState } from "react";
-import { useWindowDimensions } from "react-native";
 import {
-  KeyboardAvoidingView,
-  Platform,
-  Pressable,
   StyleSheet,
   Text,
   TextInput,
-  TouchableOpacity,
+  useWindowDimensions,
   View,
 } from "react-native";
 
@@ -45,7 +41,6 @@ export default function Compose() {
               backgroundColor: "#D1D1D6",
               borderRadius: 8,
               paddingHorizontal: 16,
-              outline: "none",
               marginBottom: 16,
               minWidth: width / 2,
             }}

--- a/apps/demo/app/(app)/index.tsx
+++ b/apps/demo/app/(app)/index.tsx
@@ -37,7 +37,7 @@ function Index() {
 
 function useQueriedNotes() {
   const notes = useNotes();
-  const { q } = useSearchParams();
+  const { q } = useSearchParams<{ q: string }>();
 
   return useMemo(
     () =>
@@ -45,7 +45,7 @@ function useQueriedNotes() {
         if (!q) {
           return true;
         }
-        return item.text.toLowerCase().includes(q.toLowerCase());
+        return item.text.toLowerCase().includes(q?.toLowerCase());
       }),
     [q, notes.notes]
   );
@@ -215,7 +215,7 @@ function Footer() {
 }
 
 function ListEmptyComponent() {
-  const { q } = useSearchParams();
+  const { q } = useSearchParams<{ q?: string }>();
 
   const message = React.useMemo(() => {
     return q != null ? "No items found: " + q : "Create an item to get started";

--- a/apps/demo/context/auth.tsx
+++ b/apps/demo/context/auth.tsx
@@ -1,6 +1,7 @@
 import { useRouter, useSegments } from "expo-router";
 import React from "react";
 import { useAsyncStorage } from "@react-native-async-storage/async-storage";
+import { StackActions, useNavigation } from "@react-navigation/core";
 
 const AuthContext = React.createContext(null);
 
@@ -11,7 +12,7 @@ export function useAuth() {
 function useProtectedRoute(user) {
   const rootSegment = useSegments()[0];
   const router = useRouter();
-
+  const nav = useNavigation();
   React.useEffect(() => {
     if (user === undefined) {
       return;
@@ -22,11 +23,22 @@ function useProtectedRoute(user) {
       !user &&
       rootSegment !== "(auth)"
     ) {
+      // nav.dispatch(
+      //   StackActions.replace("(auth)/sign-in", {
+      //     // user: 'jane',
+      //   })
+      // );
       // Redirect to the sign-in page.
       router.replace("/sign-in");
     } else if (user && rootSegment !== "(app)") {
       // Redirect away from the sign-in page.
       router.replace("/");
+      // router.replace("/compose");
+      // nav.dispatch(
+      //   StackActions.replace("(app)", {
+      //     // user: 'jane',
+      //   })
+      // );
     }
   }, [user, rootSegment]);
 }

--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### 🎉 New features
 
 - Parse any URL prefix to enable automatic Android App Links handling.
+- Support replacement to nested initial screens.
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-router/src/link/__tests__/stateOperations.test.node.ts
+++ b/packages/expo-router/src/link/__tests__/stateOperations.test.node.ts
@@ -2,7 +2,112 @@ import {
   isMovingToSiblingRoute,
   findTopRouteForTarget,
   getQualifiedStateForTopOfTargetState,
+  getEarliestMismatchedRoute,
 } from "../stateOperations";
+
+describe(getEarliestMismatchedRoute, () => {
+  it(`finds earliest mismatched route`, () => {
+    expect(
+      getEarliestMismatchedRoute(
+        {
+          type: "tab",
+          index: 0,
+          routes: [
+            {
+              name: "root",
+              state: {
+                type: "stack",
+                index: 0,
+                routes: [
+                  {
+                    name: "(auth)/sign-in",
+                  },
+                ],
+              },
+            },
+            {
+              name: "_sitemap",
+            },
+            {
+              name: "[...404]",
+            },
+          ],
+        },
+        {
+          name: "root",
+          path: "",
+          initial: true,
+          screen: "root",
+          params: {
+            initial: true,
+            screen: "(app)",
+            path: "",
+            params: {
+              initial: true,
+              screen: "index",
+              path: "/root",
+            },
+          },
+        }
+      )
+    ).toEqual({
+      name: "(app)",
+      type: "stack",
+      params: {
+        initial: true,
+        path: "/root",
+        screen: "index",
+      },
+    });
+  });
+
+  it(`returns top-level match`, () => {
+    expect(
+      getEarliestMismatchedRoute(
+        {
+          type: "tab",
+          index: 1,
+          routes: [
+            {
+              name: "root",
+            },
+            {
+              name: "_sitemap",
+            },
+            {
+              name: "[...404]",
+            },
+          ],
+        },
+        {
+          name: "root",
+          path: "",
+          initial: true,
+          screen: "root",
+          params: {
+            initial: true,
+            screen: "(app)",
+            path: "",
+            params: {
+              initial: true,
+              screen: "index",
+              path: "/root",
+            },
+          },
+        }
+      )
+    ).toEqual({
+      name: "root",
+      params: {
+        initial: true,
+        params: { initial: true, path: "/root", screen: "index" },
+        path: "",
+        screen: "(app)",
+      },
+      type: "tab",
+    });
+  });
+});
 
 describe(findTopRouteForTarget, () => {
   it(`finds the top route`, () => {

--- a/packages/expo-router/src/link/__tests__/useLinkToPath.test.node.ts
+++ b/packages/expo-router/src/link/__tests__/useLinkToPath.test.node.ts
@@ -1,0 +1,53 @@
+import { isAbsoluteInitialRoute } from "../useLinkToPath";
+
+describe(isAbsoluteInitialRoute, () => {
+  it(`returns true when a nested action is absolutely initial`, () => {
+    expect(
+      isAbsoluteInitialRoute({
+        type: "NAVIGATE",
+        payload: {
+          name: "root",
+          params: {
+            initial: true,
+            screen: "(app)",
+            params: {
+              initial: true,
+              screen: "index",
+              path: "/root",
+            },
+          },
+        },
+      })
+    ).toBe(true);
+  });
+  it(`returns true when a nested action is absolutely initial (shallow)`, () => {
+    expect(
+      isAbsoluteInitialRoute({
+        type: "NAVIGATE",
+        payload: {
+          name: "root",
+          params: undefined,
+        },
+      })
+    ).toBe(true);
+  });
+  it(`returns false when a nested action is not absolutely initial`, () => {
+    expect(
+      isAbsoluteInitialRoute({
+        type: "NAVIGATE",
+        payload: {
+          name: "root",
+          params: {
+            initial: true,
+            screen: "(app)",
+            params: {
+              initial: false,
+              screen: "index",
+              path: "/root",
+            },
+          },
+        },
+      })
+    ).toBe(false);
+  });
+});

--- a/packages/expo-router/src/link/stateOperations.ts
+++ b/packages/expo-router/src/link/stateOperations.ts
@@ -2,6 +2,13 @@ import { InitialState } from "@react-navigation/native";
 
 import { ResultState } from "../fork/getStateFromPath";
 
+export type ActionParams = {
+  params?: ActionParams;
+  path: string;
+  initial: boolean;
+  screen: string;
+};
+
 // Get the last state for a given target state (generated from a path).
 function findTopStateForTarget(state: ResultState) {
   let current: Partial<InitialState> | undefined = state;
@@ -86,4 +93,48 @@ export function getQualifiedStateForTopOfTargetState(
   }
 
   return currentRoot;
+}
+
+type SubState = {
+  type: string;
+  routes?: { name: string; state?: SubState }[];
+  index?: number;
+};
+
+// Given the root state and a target state from `getStateFromPath`,
+// return the root state containing the highest target route matching the root state.
+// This can be used to determine what type of navigator action should be used.
+export function getEarliestMismatchedRoute(
+  rootState: SubState | undefined,
+  actionParams: ActionParams & { name?: string }
+): { name: string; params?: any; type?: string } | null {
+  const actionName = actionParams.name ?? actionParams.screen;
+  if (!rootState?.routes || rootState.index == null) {
+    // This should never happen where there's more action than state.
+    return {
+      name: actionName,
+      type: "stack",
+    };
+  }
+
+  const nextCurrentRoot = rootState.routes[rootState.index];
+  if (actionName === nextCurrentRoot.name) {
+    if (!actionParams.params) {
+      // All routes match all the way up, no change required.
+      return null;
+    }
+
+    return getEarliestMismatchedRoute(
+      nextCurrentRoot.state,
+      actionParams.params
+    );
+  }
+
+  // There's a selected state but it doesn't match the action state
+  // this is now the lowest point of change.
+  return {
+    name: actionName,
+    params: actionParams.params,
+    type: rootState.type,
+  };
 }


### PR DESCRIPTION
# Motivation

- Partially resolve https://github.com/expo/router/issues/233

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# Execution

- Implement a system to find the nearest possible replacement across navigators.
- If it's possible to navigate across navigators without pushing history, then we will now do that by traversing the tree for initial routes, and replacing to the nearest common ancestor.
- This does not implement batching actions so a replacement to a non-initial route will still add multiple history entries. e.g. replace to a screen that must be pushed on a stack. This is conceptually similar to signing in to Twitter and replacing to a tweet, the tweet would have a back button to the feed and therefore would require a history entry to satisfy this constraint.


<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

- The `apps/demo` example is prime as it navigates to a nested stack where the first page is initial.
- Added tests for the state operation I added.

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
