### PR TITLE
Use long-form flag, disambiguate template / example

### DIFF
--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -12,10 +12,10 @@ Expo Router brings the best routing concepts from the web to native iOS and Andr
 Run the following to create a project with `expo-router` setup:
 
 ```bash
-npx create-expo-app@latest -e with-router
+npx create-expo-app@latest --example with-router
 ```
 
-> [Template source](https://github.com/expo/examples/tree/master/with-router).
+> [Example source](https://github.com/expo/examples/tree/master/with-router).
 
 ## Features
 


### PR DESCRIPTION
# Motivation

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

- Long-form flags are more expressive and help with understanding what the flag should mean (especially important with an undocumented flag like `-e` / `--example`)
- The word "template" means to me something different than [Examples](https://github.com/expo/examples), indicates something closer to what you would be using with the `--template` flag

# Execution

<!--
How did you build this feature or fix this bug and why?
-->

Updated the documentation

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Check whether the updated documentation makes sense and matches the goals of the Expo Router project