### PR TITLE
refactor: remove ts-expect-error from error-overlay

### DIFF
--- a/packages/expo-metro-runtime/src/error-overlay/Data/LogBoxData.tsx
+++ b/packages/expo-metro-runtime/src/error-overlay/Data/LogBoxData.tsx
@@ -365,7 +365,10 @@ export function observe(observer: Observer): Subscription {
 export function withSubscription(
   WrappedComponent: React.FC<object>
 ): React.Component<object> {
-  class LogBoxStateSubscription extends React.Component<Props, State> {
+  class LogBoxStateSubscription extends React.Component<
+    React.PropsWithChildren<Props>,
+    State
+  > {
     static getDerivedStateFromError() {
       return { hasError: true };
     }
@@ -378,9 +381,8 @@ export function withSubscription(
 
     _subscription?: Subscription;
 
-    // @ts-expect-error
     state = {
-      logs: new Set(),
+      logs: new Set<LogBoxLog>(),
       isDisabled: false,
       hasError: false,
       selectedLogIndex: -1,
@@ -398,11 +400,9 @@ export function withSubscription(
           value={{
             selectedLogIndex: this.state.selectedLogIndex,
             isDisabled: this.state.isDisabled,
-            // @ts-expect-error
             logs: Array.from(this.state.logs),
           }}
         >
-          {/* @ts-expect-error */}
           {this.props.children}
           <WrappedComponent />
         </LogContext.Provider>
@@ -434,7 +434,6 @@ export function withSubscription(
           setSelectedLog(selectedLogIndex - 1);
         }
 
-        // @ts-expect-error
         dismiss(logsArray[selectedLogIndex]);
       }
     };

--- a/packages/expo-metro-runtime/src/error-overlay/Data/parseLogBoxLog.tsx
+++ b/packages/expo-metro-runtime/src/error-overlay/Data/parseLogBoxLog.tsx
@@ -53,10 +53,10 @@ export type ComponentStack = CodeFrame[];
 
 const SUBSTITUTION = UTFSequence.BOM + "%s";
 
-export function parseInterpolation(args: readonly any[]): readonly {
+export function parseInterpolation(args: readonly any[]): {
   category: Category;
   message: Message;
-}[] {
+} {
   const categoryParts: string[] = [];
   const contentParts: string[] = [];
   const substitutionOffsets: { length: number; offset: number }[] = [];
@@ -120,7 +120,6 @@ export function parseInterpolation(args: readonly any[]): readonly {
   contentParts.push(...remainingArgs);
 
   return {
-    // @ts-expect-error
     category: categoryParts.join(" "),
     message: {
       content: contentParts.join(" "),
@@ -278,7 +277,6 @@ export function parseLogBoxException(
 
   const componentStack = error.componentStack;
   if (error.isFatal || error.isComponentError) {
-    // @ts-expect-error
     return {
       level: "fatal",
       stack: error.stack,
@@ -291,7 +289,6 @@ export function parseLogBoxException(
 
   if (componentStack != null) {
     // It is possible that console errors have a componentStack.
-    // @ts-expect-error
     return {
       level: "error",
       stack: error.stack,
@@ -355,7 +352,6 @@ export function parseLogBoxLog(args: readonly any[]): {
     }
   }
 
-  // @ts-expect-error
   return {
     ...parseInterpolation(argsWithoutComponentStack),
     componentStack,

--- a/packages/expo-metro-runtime/src/error-overlay/modules/NativeLogBox/index.tsx
+++ b/packages/expo-metro-runtime/src/error-overlay/modules/NativeLogBox/index.tsx
@@ -6,15 +6,14 @@ export default {
     if (currentRoot) {
       return;
     }
-    const ErrorOverlay = require("../../ErrorOverlay")
-      .default as typeof import("../../ErrorOverlay").default;
+    const ErrorOverlay: React.ComponentType =
+      require("../../ErrorOverlay").default;
     // Create a new div with ID `error-overlay` element and render LogBoxInspector into it.
     const div = document.createElement("div");
     div.id = "error-overlay";
     document.body.appendChild(div);
 
     currentRoot = ReactDOM.createRoot(div);
-    // @ts-expect-error
     currentRoot.render(<ErrorOverlay />);
   },
   hide() {

--- a/packages/expo-metro-runtime/src/error-overlay/modules/stringifySafe/index.ts
+++ b/packages/expo-metro-runtime/src/error-overlay/modules/stringifySafe/index.ts
@@ -23,8 +23,7 @@ export function createStringifySafeWithLimits(limits: {
     maxObjectKeysLimit = Number.POSITIVE_INFINITY,
   } = limits;
   const stack: any[] = [];
-  function replacer(key: string, value: any): any {
-    // @ts-expect-error
+  function replacer(this: unknown, _key: string, value: any): any {
     while (stack.length && this !== stack[0]) {
       stack.shift();
     }


### PR DESCRIPTION
# Overview

`ts-expect-error` cleanup. Only notable was `parseInterpolation` returning a readonly array, but all usage returns an object.