### PR TITLE
refactor: remove ts-expect-error from link

### DIFF
--- a/packages/expo-router/src/NavigationContainer.tsx
+++ b/packages/expo-router/src/NavigationContainer.tsx
@@ -7,7 +7,7 @@ import { RootNavigationRef } from "./useRootNavigation";
 import { useRootRouteNodeContext } from "./useRootRouteNodeContext";
 import { SplashScreen } from "./views/Splash";
 
-const navigationRef = createNavigationContainerRef();
+const navigationRef = createNavigationContainerRef<Record<string, unknown>>();
 
 /** Get the root navigation container ref. */
 export function getNavigationContainerRef() {

--- a/packages/expo-router/src/link/stateOperations.ts
+++ b/packages/expo-router/src/link/stateOperations.ts
@@ -1,4 +1,4 @@
-import { InitialState } from "@react-navigation/native";
+import { InitialState, NavigationState } from "@react-navigation/native";
 
 import { ResultState } from "../fork/getStateFromPath";
 
@@ -95,7 +95,8 @@ export function getQualifiedStateForTopOfTargetState(
   return currentRoot;
 }
 
-type SubState = {
+type SubState = NavigationState & {
+  key?: string;
   type: string;
   routes?: { name: string; state?: SubState }[];
   index?: number;

--- a/packages/expo-router/src/link/useLinkToPath.ts
+++ b/packages/expo-router/src/link/useLinkToPath.ts
@@ -54,7 +54,6 @@ export function useLinkToPath() {
       if (href.startsWith(".")) {
         let base = linking.getPathFromState?.(navigation.getRootState(), {
           ...linking.config,
-          // @ts-expect-error: non-standard option
           preserveGroups: true,
         });
 
@@ -123,8 +122,8 @@ export function useLinkToPath() {
           isAbsoluteInitialRoute(action)
         ) {
           const earliest = getEarliestMismatchedRoute(
-            // @ts-expect-error
             rootState,
+            // @ts-expect-error
             action.payload
           );
           if (earliest) {

--- a/packages/expo-router/src/link/useLinkToPathProps.tsx
+++ b/packages/expo-router/src/link/useLinkToPathProps.tsx
@@ -5,20 +5,26 @@ import { useLinkToPath } from "./useLinkToPath";
 import { stripGroupSegmentsFromPath } from "../matchers";
 
 function eventShouldPreventDefault(
-  e?: React.MouseEvent<HTMLAnchorElement, MouseEvent> | GestureResponderEvent
+  e: React.MouseEvent<HTMLAnchorElement, MouseEvent> | GestureResponderEvent
 ): boolean {
+  if (e?.defaultPrevented) {
+    return false;
+  }
+
   if (
-    !!e &&
-    !e.defaultPrevented && // onPress prevented default
-    // @ts-expect-error: these properties exist on web, but not in React Native
-    !(e.metaKey || e.altKey || e.ctrlKey || e.shiftKey) && // ignore clicks with modifier keys
-    // @ts-expect-error: these properties exist on web, but not in React Native
-    (e.button == null || e.button === 0) && // ignore everything but left clicks
-    // @ts-expect-error: these properties exist on web, but not in React Native
-    [undefined, null, "", "self"].includes(e.currentTarget?.target) // let browser handle "target=_blank" etc.
+    // Only check MouseEvents
+    "button" in e &&
+    // ignore clicks with modifier keys
+    !e.metaKey &&
+    !e.altKey &&
+    !e.ctrlKey &&
+    !e.shiftKey &&
+    (e.button == null || e.button === 0) && // Only accept left clicks
+    [undefined, null, "", "self"].includes(e.currentTarget.target) // let browser handle "target=_blank" etc.
   ) {
     return true;
   }
+
   return false;
 }
 

--- a/packages/expo-router/src/link/useLinkingContext.ts
+++ b/packages/expo-router/src/link/useLinkingContext.ts
@@ -5,20 +5,31 @@ import {
 } from "@react-navigation/native";
 import * as React from "react";
 
-export function useLinkingContext(): Required<
+import getPathFromState from "../fork/getPathFromState";
+
+export type RouterLinkingContext = Required<
   Omit<LinkingOptions<ParamListBase>, "filter" | "enabled">
-> {
+> & {
+  getPathFromState: typeof getPathFromState;
+};
+
+export function useLinkingContext(): RouterLinkingContext {
   const linking = React.useContext(LinkingContext);
 
   const { options } = linking;
 
+  assertLinkingOptions(options);
+
+  return options;
+}
+
+function assertLinkingOptions(
+  options: LinkingOptions<ParamListBase> | undefined
+): asserts options is RouterLinkingContext {
   if (!options?.config) {
     // This should never happen in Expo Router.
     throw new Error(
       "Couldn't find a linking config. Is your component inside a navigator?"
     );
   }
-
-  // @ts-expect-error: non-standard option
-  return options;
 }

--- a/packages/expo-router/src/link/useRouter.ts
+++ b/packages/expo-router/src/link/useRouter.ts
@@ -47,11 +47,8 @@ export function useRouter(): Router {
     push,
     back,
     replace,
-    setParams: (params) => {
-      root?.current?.setParams(
-        // @ts-expect-error
-        params
-      );
+    setParams: (params = {}) => {
+      root?.current?.setParams(params);
     },
     // TODO(EvanBacon): add `reload`
     // TODO(EvanBacon): add `canGoBack` but maybe more like a `hasContext`


### PR DESCRIPTION
# Overview

Continued cleanup of `ts-expect-error`. See comments for individual feedback
