### PR TITLE
fix: use `createElement` for static `div`.

### DIFF
--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Use `createElement` for static `div`.
+
 ### 💡 Others
 
 ## [Tue, 28 Feb 2023 12:13:09 -0600](https://github.com/expo/router/commit/a61fe6dfed89f52d69fdd226278f58ec3a8dfa19)

--- a/packages/expo-router/src/static/renderStaticContent.tsx
+++ b/packages/expo-router/src/static/renderStaticContent.tsx
@@ -31,12 +31,15 @@ export function getStaticContent(location: URL): string {
     // TODO: Use RNW view after they fix hydration for React 18
     // https://github.com/necolas/react-native-web/blob/e8098fd029102d7801c32c1ede792bce01808c00/packages/react-native-web/src/exports/render/index.js#L10
     // Otherwise this wraps the app with two extra divs
-    children: (
-      // Inject the root tag
-      <div id="root">
+    children:
+      // Inject the root tag using createElement to prevent any transforms like the ones in `@expo/html-elements`.
+      React.createElement(
+        "div",
+        {
+          id: "root",
+        },
         <App />
-      </div>
-    ),
+      ),
   });
 
   const html = ReactDOMServer.renderToString(


### PR DESCRIPTION
# Motivation

Prevent `@expo/html-elements` from transforming. Related https://github.com/expo/expo/pull/21594


