### PR TITLE
fix: fix problematic ts-expect-error

### DIFF
--- a/packages/expo-router/src/fork/getStateFromPath.ts
+++ b/packages/expo-router/src/fork/getStateFromPath.ts
@@ -472,8 +472,7 @@ const createNormalizedConfigs = (
 
   parentScreens.push(screen);
 
-  // @ts-expect-error
-  const config = routeConfig[screen];
+  const config = (routeConfig as any)[screen];
 
   if (typeof config === "string") {
     // If a string is specified as the value of the key(e.g. Foo: '/path'), use it as the pattern


### PR DESCRIPTION
# Motivation

Some TS configs appear failing on this line. This is a band-aid fix to solve the issue. I believe a problem fix would be to emit `.d.ts` declarations to stop `tsc` processing the expo-router internals.

# Execution

`config` was already typed as `any`. This just forces it another way.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
