### PR TITLE
Fix deep linking for app urls

### DIFF
--- a/packages/expo-router/package.json
+++ b/packages/expo-router/package.json
@@ -63,7 +63,6 @@
   },
   "devDependencies": {
     "@react-navigation/drawer": "^6.6.2",
-    "@types/url-parse": "^1.4.8",
     "expo-splash-screen": "~0.18.1",
     "expo-status-bar": "~1.4.4",
     "react-native-gesture-handler": "~2.9.0",

--- a/packages/expo-router/src/fork/__tests__/__snapshots__/extractPathFromURL.test.ios.ts.snap
+++ b/packages/expo-router/src/fork/__tests__/__snapshots__/extractPathFromURL.test.ios.ts.snap
@@ -1,39 +1,39 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`extractExpoPathFromURL parses "custom://" 1`] = `""`;
+exports[`extractPathFromURL parses "custom://" 1`] = `""`;
 
-exports[`extractExpoPathFromURL parses "custom:///" 1`] = `""`;
+exports[`extractPathFromURL parses "custom:///" 1`] = `""`;
 
-exports[`extractExpoPathFromURL parses "custom://?hello=bar" 1`] = `"?hello=bar"`;
+exports[`extractPathFromURL parses "custom://?hello=bar" 1`] = `"?hello=bar"`;
 
-exports[`extractExpoPathFromURL parses "custom://?shouldBeEscaped=x%252By%2540xxx.com" 1`] = `"?shouldBeEscaped=x+y@xxx.com"`;
+exports[`extractPathFromURL parses "custom://?shouldBeEscaped=x%252By%2540xxx.com" 1`] = `"?shouldBeEscaped=x+y@xxx.com"`;
 
-exports[`extractExpoPathFromURL parses "custom://test/path?foo=bar" 1`] = `"test/path?foo=bar"`;
+exports[`extractPathFromURL parses "custom://test/path?foo=bar" 1`] = `"test/path?foo=bar"`;
 
-exports[`extractExpoPathFromURL parses "exp://127.0.0.1:19000/" 1`] = `""`;
+exports[`extractPathFromURL parses "exp://127.0.0.1:19000/" 1`] = `""`;
 
-exports[`extractExpoPathFromURL parses "exp://127.0.0.1:19000/--/test/path?query=param" 1`] = `"test/path?query=param"`;
+exports[`extractPathFromURL parses "exp://127.0.0.1:19000/--/test/path?query=param" 1`] = `"test/path?query=param"`;
 
-exports[`extractExpoPathFromURL parses "exp://127.0.0.1:19000?query=param" 1`] = `"?query=param"`;
+exports[`extractPathFromURL parses "exp://127.0.0.1:19000?query=param" 1`] = `"?query=param"`;
 
-exports[`extractExpoPathFromURL parses "exp://exp.host/@test/test/--/test/path" 1`] = `"test/path"`;
+exports[`extractPathFromURL parses "exp://exp.host/@test/test/--/test/path" 1`] = `"test/path"`;
 
-exports[`extractExpoPathFromURL parses "exp://exp.host/@test/test/--/test/path/--/foobar" 1`] = `"test/path/--/foobar"`;
+exports[`extractPathFromURL parses "exp://exp.host/@test/test/--/test/path/--/foobar" 1`] = `"test/path/--/foobar"`;
 
-exports[`extractExpoPathFromURL parses "exp://exp.host/@test/test/--/test/path?query=param" 1`] = `"test/path?query=param"`;
+exports[`extractPathFromURL parses "exp://exp.host/@test/test/--/test/path?query=param" 1`] = `"test/path?query=param"`;
 
-exports[`extractExpoPathFromURL parses "https://example.com/test/path" 1`] = `"test/path"`;
+exports[`extractPathFromURL parses "https://example.com/test/path" 1`] = `"test/path"`;
 
-exports[`extractExpoPathFromURL parses "https://example.com/test/path?missingQueryValue=" 1`] = `"test/path?missingQueryValue="`;
+exports[`extractPathFromURL parses "https://example.com/test/path?missingQueryValue=" 1`] = `"test/path?missingQueryValue="`;
 
-exports[`extractExpoPathFromURL parses "https://example.com/test/path?query=do+not+escape" 1`] = `"test/path?query=do not escape"`;
+exports[`extractPathFromURL parses "https://example.com/test/path?query=do+not+escape" 1`] = `"test/path?query=do not escape"`;
 
-exports[`extractExpoPathFromURL parses "https://example.com/test/path?query=param" 1`] = `"test/path?query=param"`;
+exports[`extractPathFromURL parses "https://example.com/test/path?query=param" 1`] = `"test/path?query=param"`;
 
-exports[`extractExpoPathFromURL parses "https://example.com:8000/test/path" 1`] = `"test/path"`;
+exports[`extractPathFromURL parses "https://example.com:8000/test/path" 1`] = `"test/path"`;
 
-exports[`extractExpoPathFromURL parses "https://example.com:8000/test/path+with+plus" 1`] = `"with+plus"`;
+exports[`extractPathFromURL parses "https://example.com:8000/test/path+with+plus" 1`] = `"with+plus"`;
 
-exports[`extractExpoPathFromURL parses "invalid" 1`] = `"invalid"`;
+exports[`extractPathFromURL parses "invalid" 1`] = `"invalid"`;
 
-exports[`extractExpoPathFromURL parses "invalid" 2`] = `"invalid"`;
+exports[`extractPathFromURL parses "invalid" 2`] = `"invalid"`;

--- a/packages/expo-router/src/fork/__tests__/__snapshots__/extractPathFromURL.test.ios.ts.snap
+++ b/packages/expo-router/src/fork/__tests__/__snapshots__/extractPathFromURL.test.ios.ts.snap
@@ -35,5 +35,3 @@ exports[`extractPathFromURL parses "https://example.com:8000/test/path" 1`] = `"
 exports[`extractPathFromURL parses "https://example.com:8000/test/path+with+plus" 1`] = `"with+plus"`;
 
 exports[`extractPathFromURL parses "invalid" 1`] = `"invalid"`;
-
-exports[`extractPathFromURL parses "invalid" 2`] = `"invalid"`;

--- a/packages/expo-router/src/fork/__tests__/__snapshots__/extractPathFromURL.test.ios.ts.snap
+++ b/packages/expo-router/src/fork/__tests__/__snapshots__/extractPathFromURL.test.ios.ts.snap
@@ -4,11 +4,11 @@ exports[`extractExpoPathFromURL parses "custom://" 1`] = `""`;
 
 exports[`extractExpoPathFromURL parses "custom:///" 1`] = `""`;
 
-exports[`extractExpoPathFromURL parses "custom:///?shouldBeEscaped=x%252By%2540xxx.com" 1`] = `"?shouldBeEscaped=x+y@xxx.com"`;
-
-exports[`extractExpoPathFromURL parses "custom:///test/path?foo=bar" 1`] = `"test/path?foo=bar"`;
-
 exports[`extractExpoPathFromURL parses "custom://?hello=bar" 1`] = `"?hello=bar"`;
+
+exports[`extractExpoPathFromURL parses "custom://?shouldBeEscaped=x%252By%2540xxx.com" 1`] = `"?shouldBeEscaped=x+y@xxx.com"`;
+
+exports[`extractExpoPathFromURL parses "custom://test/path?foo=bar" 1`] = `"test/path?foo=bar"`;
 
 exports[`extractExpoPathFromURL parses "exp://127.0.0.1:19000/" 1`] = `""`;
 
@@ -35,3 +35,5 @@ exports[`extractExpoPathFromURL parses "https://example.com:8000/test/path" 1`] 
 exports[`extractExpoPathFromURL parses "https://example.com:8000/test/path+with+plus" 1`] = `"with+plus"`;
 
 exports[`extractExpoPathFromURL parses "invalid" 1`] = `"invalid"`;
+
+exports[`extractExpoPathFromURL parses "invalid" 2`] = `"invalid"`;

--- a/packages/expo-router/src/fork/__tests__/extractPathFromURL.test.ios.ts
+++ b/packages/expo-router/src/fork/__tests__/extractPathFromURL.test.ios.ts
@@ -1,10 +1,10 @@
 import Constants, { ExecutionEnvironment } from "expo-constants";
 
-import { extractExpoPathFromURL } from "../extractPathFromURL";
+import { extractPathFromURL } from "../extractPathFromURL";
 
 jest.mock("expo-constants");
 
-describe(extractExpoPathFromURL, () => {
+describe(extractPathFromURL, () => {
   const originalExecutionEnv = Constants.executionEnvironment;
   const originalExpoConfig = Constants.expoConfig;
 
@@ -30,7 +30,7 @@ describe(extractExpoPathFromURL, () => {
   ])(`parses %p`, (url) => {
     Constants.executionEnvironment = ExecutionEnvironment.StoreClient;
 
-    const res = extractExpoPathFromURL(url);
+    const res = extractPathFromURL(url);
     expect(res).toMatchSnapshot();
     // Ensure the Expo Go handling never breaks
     expect(res).not.toMatch(/^--\//);
@@ -49,7 +49,7 @@ describe(extractExpoPathFromURL, () => {
       scheme: "custom",
     }
 
-    const res = extractExpoPathFromURL(url);
+    const res = extractPathFromURL(url);
     expect(res).toMatchSnapshot();
     // Ensure the Expo Go handling never breaks
     expect(res).not.toMatch(/^--\//);
@@ -58,7 +58,7 @@ describe(extractExpoPathFromURL, () => {
   it(`only handles Expo Go URLs in Expo Go`, () => {
     Constants.executionEnvironment = ExecutionEnvironment.Bare;
 
-    const res = extractExpoPathFromURL("exp://127.0.0.1:19000/--/test");
+    const res = extractPathFromURL("exp://127.0.0.1:19000/--/test");
     expect(res).toEqual("--/test");
   });
 });

--- a/packages/expo-router/src/fork/extractPathFromURL.ts
+++ b/packages/expo-router/src/fork/extractPathFromURL.ts
@@ -13,10 +13,16 @@ export function extractExpoPathFromURL(url: string) {
   }
 
   const res = Linking.parse(url);
+  const isAppUrl = Constants.expoConfig?.scheme === res.scheme;
+
   const qs = !res.queryParams
     ? ""
     : Object.entries(res.queryParams)
         .map(([k, v]) => `${k}=${v}`)
         .join("&");
-  return (res.path || "") + (qs ? "?" + qs : "");
+  return (
+    (isAppUrl && res.hostname ? res.hostname + "/" : "") +
+    (res.path || "") +
+    (qs ? "?" + qs : "")
+  );
 }

--- a/packages/expo-router/src/fork/extractPathFromURL.ts
+++ b/packages/expo-router/src/fork/extractPathFromURL.ts
@@ -13,7 +13,7 @@ export function extractExpoPathFromURL(url: string) {
   }
 
   const res = Linking.parse(url);
-  const isAppUrl = Constants.expoConfig?.scheme === res.scheme;
+  const isAppDeepLink = res.scheme && !["https", "https"].includes(res.scheme);
 
   const qs = !res.queryParams
     ? ""
@@ -21,7 +21,7 @@ export function extractExpoPathFromURL(url: string) {
         .map(([k, v]) => `${k}=${v}`)
         .join("&");
   return (
-    (isAppUrl && res.hostname ? res.hostname + "/" : "") +
+    (isAppDeepLink && res.hostname ? res.hostname + "/" : "") +
     (res.path || "") +
     (qs ? "?" + qs : "")
   );

--- a/packages/expo-router/src/fork/extractPathFromURL.ts
+++ b/packages/expo-router/src/fork/extractPathFromURL.ts
@@ -13,7 +13,12 @@ export function extractPathFromURL(url: string) {
   }
 
   const res = Linking.parse(url);
-  const isAppDeepLink = res.scheme && !["https", "https"].includes(res.scheme);
+  const isAppDeepLink =
+    /**
+     * needs to explicitely exclude expo urls as well, as the above regex
+     * only deals with the ones that contain "--"
+     */
+    res.scheme && !["https", "https", "exp", "exps"].includes(res.scheme);
 
   const qs = !res.queryParams
     ? ""

--- a/packages/expo-router/src/fork/extractPathFromURL.ts
+++ b/packages/expo-router/src/fork/extractPathFromURL.ts
@@ -2,7 +2,7 @@ import Constants, { ExecutionEnvironment } from "expo-constants";
 import * as Linking from "expo-linking";
 
 // This is only run on native.
-export function extractExpoPathFromURL(url: string) {
+export function extractPathFromURL(url: string) {
   // Handle special URLs used in Expo Go: `/--/pathname` -> `pathname`
   if (Constants.executionEnvironment === ExecutionEnvironment.StoreClient) {
     const pathname = url.match(/exps?:\/\/.*?\/--\/(.*)/)?.[1];

--- a/packages/expo-router/src/fork/useLinking.native.ts
+++ b/packages/expo-router/src/fork/useLinking.native.ts
@@ -12,7 +12,7 @@ import type { LinkingOptions } from "@react-navigation/native";
 import * as React from "react";
 import { Linking, Platform } from "react-native";
 
-import { extractExpoPathFromURL } from "./extractPathFromURL";
+import { extractPathFromURL } from "./extractPathFromURL";
 
 type ResultState = ReturnType<typeof getStateFromPathDefault>;
 
@@ -129,7 +129,7 @@ export default function useLinking(
       }
 
       // NOTE(EvanBacon): This is the important part.
-      const path = extractExpoPathFromURL(url);
+      const path = extractPathFromURL(url);
 
       return path !== undefined
         ? getStateFromPathRef.current(path, configRef.current)

--- a/packages/expo-router/src/useInitialRootState.native.tsx
+++ b/packages/expo-router/src/useInitialRootState.native.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 
-import { extractExpoPathFromURL } from "./fork/extractPathFromURL";
+import { extractPathFromURL } from "./fork/extractPathFromURL";
 import { State } from "./fork/getPathFromState";
 import { useLinkingContext } from "./link/useLinkingContext";
 
@@ -24,7 +24,7 @@ export function useInitialRootState() {
   useEffect(() => {
     if (url) {
       // TODO: Add hashes to the path
-      const urlWithoutOrigin = extractExpoPathFromURL(url);
+      const urlWithoutOrigin = extractPathFromURL(url);
       setState(linking.getStateFromPath(urlWithoutOrigin, linking.config)!);
     }
   }, [url, linking]);

--- a/packages/expo-router/src/useInitialRootState.native.tsx
+++ b/packages/expo-router/src/useInitialRootState.native.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
-import URL from "url-parse";
 
+import { extractExpoPathFromURL } from "./fork/extractPathFromURL";
 import { State } from "./fork/getPathFromState";
 import { useLinkingContext } from "./link/useLinkingContext";
 
@@ -23,10 +23,8 @@ export function useInitialRootState() {
 
   useEffect(() => {
     if (url) {
-      const parsed = URL(url);
       // TODO: Add hashes to the path
-      const urlWithoutOrigin = parsed.pathname + parsed.query;
-
+      const urlWithoutOrigin = extractExpoPathFromURL(url);
       setState(linking.getStateFromPath(urlWithoutOrigin, linking.config)!);
     }
   }, [url, linking]);

--- a/yarn.lock
+++ b/yarn.lock
@@ -3659,11 +3659,6 @@
   dependencies:
     source-map "^0.6.1"
 
-"@types/url-parse@^1.4.8":
-  version "1.4.8"
-  resolved "https://registry.yarnpkg.com/@types/url-parse/-/url-parse-1.4.8.tgz#c3825047efbca1295b7f1646f38203d9145130d6"
-  integrity sha512-zqqcGKyNWgTLFBxmaexGUKQyWqeG7HjXj20EuQJSJWwXe54BjX0ihIo5cJB9yAQzH8dNugJ9GvkBYMjPXs/PJw==
-
 "@types/webpack-sources@*":
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/@types/webpack-sources/-/webpack-sources-3.2.0.tgz#16d759ba096c289034b26553d2df1bf45248d38b"


### PR DESCRIPTION
# Motivation
fixes #362 

# Execution
Compare uri scheme of the app with the link to handle links of the app itself. See https://github.com/expo/router/issues/362#issuecomment-1465077659 for in dephts explanation

# Test Plan
I adjusted the the existing snapshot tests to work with 2 slashes for custom urls instead of 3.
