### PR TITLE
Refactor tsconfig & publishing of declaration files

### DIFF
--- a/apps/demo/tsconfig.json
+++ b/apps/demo/tsconfig.json
@@ -1,8 +1,3 @@
 {
-  "extends": "expo/tsconfig.base",
-  "compilerOptions": {
-    "typeRoots": [
-      "expo-router/ts-declarations"
-    ]
-  },
+  "extends": "expo/tsconfig.base"
 }

--- a/packages/expo-metro-runtime/src/ts-declarations.d.ts
+++ b/packages/expo-metro-runtime/src/ts-declarations.d.ts
@@ -1,0 +1,1 @@
+/// <reference path="../../../ts-declarations/index.d.ts" />

--- a/packages/expo-metro-runtime/tsconfig.json
+++ b/packages/expo-metro-runtime/tsconfig.json
@@ -1,10 +1,7 @@
 {
   "extends": "../../tsconfig.base",
   "compilerOptions": {
-    "outDir": "./build",
-    "target": "es2019",
-    "module": "commonjs"
+    "outDir": "./build"
   },
-  "include": ["./src"],
-  "exclude": ["**/__mocks__/*", "**/__tests__/*"]
+  "include": ["./src"]
 }

--- a/packages/expo-router/_root.tsx
+++ b/packages/expo-router/_root.tsx
@@ -2,9 +2,9 @@
 
 import "@expo/metro-runtime";
 
-import { ExpoRoot } from "expo-router";
 import React from "react";
 
+import { ExpoRoot } from "./src";
 import { getNavigationConfig } from "./src/getLinkingConfig";
 import { getRoutes } from "./src/getRoutes";
 

--- a/packages/expo-router/package.json
+++ b/packages/expo-router/package.json
@@ -27,12 +27,12 @@
   },
   "homepage": "https://expo.github.io/router/docs/",
   "scripts": {
-    "build": "expo-module typecheck",
+    "build": "expo-module typecheck --noEmit false",
     "clean": "expo-module clean",
     "lint": "expo-module lint",
     "test": "expo-module test",
     "prepare": "expo-module prepare",
-    "prepublishOnly": "tsc --noEmit false && expo-module prepublishOnly",
+    "prepublishOnly": "expo-module prepublishOnly && expo-module typecheck --noEmit false",
     "expo-module": "expo-module"
   },
   "keywords": [

--- a/packages/expo-router/package.json
+++ b/packages/expo-router/package.json
@@ -2,9 +2,10 @@
   "name": "expo-router",
   "version": "1.2.2",
   "main": "src/index.tsx",
-  "types": "src/index.tsx",
+  "types": "build/index.d.ts",
   "files": [
     "src",
+    "build",
     "node",
     "entry.js",
     "_root.tsx",
@@ -31,7 +32,7 @@
     "lint": "expo-module lint",
     "test": "expo-module test",
     "prepare": "expo-module prepare",
-    "prepublishOnly": "expo-module prepublishOnly",
+    "prepublishOnly": "tsc --noEmit false && expo-module prepublishOnly",
     "expo-module": "expo-module"
   },
   "keywords": [

--- a/packages/expo-router/src/ts-declarations.d.ts
+++ b/packages/expo-router/src/ts-declarations.d.ts
@@ -1,0 +1,1 @@
+/// <reference path="../../../ts-declarations/index.d.ts" />

--- a/packages/expo-router/tsconfig.json
+++ b/packages/expo-router/tsconfig.json
@@ -3,11 +3,8 @@
   "compilerOptions": {
     "outDir": "./build",
     "rootDir": "./src",
-    "baseUrl": ".",
-    "noEmit": true,
-    "emitDeclarationOnly": true,
-    "skipLibCheck": true
+    "emitDeclarationOnly": true
   },
-  "include": ["src/"],
+  "include": ["./src/"],
   "exclude": ["**/__mocks__/*", "**/__tests__/*"]
 }

--- a/packages/expo-router/tsconfig.json
+++ b/packages/expo-router/tsconfig.json
@@ -1,9 +1,13 @@
 {
   "extends": "../../tsconfig.base",
   "compilerOptions": {
+    "outDir": "./build",
+    "rootDir": "./src",
+    "baseUrl": ".",
     "noEmit": true,
+    "emitDeclarationOnly": true,
     "skipLibCheck": true
   },
-  "include": ["./src"],
+  "include": ["src/"],
   "exclude": ["**/__mocks__/*", "**/__tests__/*"]
 }

--- a/ts-declarations/index.d.ts
+++ b/ts-declarations/index.d.ts
@@ -1,0 +1,5 @@
+/// <reference path="./metro-babel-transformer/index.d.ts" />
+/// <reference path="./metro-babel-transformer/index.d.ts" />
+/// <reference path="./metro-react-native-babel-transformer/index.d.ts" />
+/// <reference path="./metro-source-map/index.d.ts" />
+/// <reference path="./react-native-web/index.d.ts" />

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,7 +1,6 @@
 {
   "extends": "expo-module-scripts/tsconfig.base",
   "compilerOptions": {
-    "outDir": "./build",
     "target": "es2019",
     "module": "commonjs",
     "types": ["node", "jest"],

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -4,11 +4,6 @@
     "target": "es2019",
     "module": "commonjs",
     "types": ["node", "jest"],
-    "typeRoots": ["./ts-declarations", "./node_modules/@types"],
-    "baseUrl": ".",
-    "paths": {
-      "*": ["ts-declarations/*", "node_modules/*"]
-    },
     "strict": true
   }
 }


### PR DESCRIPTION
# Motivation

Publish Expo Router with TS declarations. 

When `types` in `package.json` points to a `.ts` file, TypeScript will always type-check the dependency - regardless of `skipLibCheck`. This adds extra burden on maintainers, as now we need to ensure every possible ts config is valid. The best solution is to point the `package.json` at generated declarations and allow users to use `skipLibCheck` (which is recommended by TS).

# Test Plan

This should be published as a preview release and tested with a couple of different project configurations.
