### PR TITLE
feat: update <Link /> types for @expo/cli typed routes

### DIFF
--- a/docs/docs/guides/auth.md
+++ b/docs/docs/guides/auth.md
@@ -16,7 +16,7 @@ app/
 
 First, we'll setup a [React Context provider](https://reactjs.org/docs/context.html) that we can use to protect routes. This provider will use a mock implementation, you can replace it with your own [authentication provider](https://docs.expo.dev/guides/authentication/).
 
-```js title=auth/provider.js
+```js title=context/auth.js
 import { useRouter, useSegments } from "expo-router";
 import React from "react";
 

--- a/packages/expo-router/src/fork/getStateFromPath.ts
+++ b/packages/expo-router/src/fork/getStateFromPath.ts
@@ -472,8 +472,7 @@ const createNormalizedConfigs = (
 
   parentScreens.push(screen);
 
-  // @ts-expect-error
-  const config = routeConfig[screen];
+  const config = (routeConfig as any)[screen];
 
   if (typeof config === "string") {
     // If a string is specified as the value of the key(e.g. Foo: '/path'), use it as the pattern

--- a/packages/expo-router/src/link/Link.tsx
+++ b/packages/expo-router/src/link/Link.tsx
@@ -10,7 +10,7 @@ import useLinkToPathProps from "./useLinkToPathProps";
 import { useRouter } from "./useRouter";
 import { useFocusEffect } from "../useFocusEffect";
 
-type Props = {
+export interface LinkProps extends Omit<TextProps, "href" | "hoverStyle"> {
   /** Path to route to. */
   href: Href;
 
@@ -24,7 +24,7 @@ type Props = {
   onPress?: (
     e: React.MouseEvent<HTMLAnchorElement, MouseEvent> | GestureResponderEvent
   ) => void;
-} & (Omit<TextProps, "href" | "hoverStyle"> & { children?: React.ReactNode });
+}
 
 /** Redirects to the href as soon as the component is mounted. */
 export function Redirect({ href }: { href: Href }) {
@@ -33,6 +33,12 @@ export function Redirect({ href }: { href: Href }) {
     router.replace(href);
   });
   return null;
+}
+
+export interface LinkComponent {
+  (props: React.PropsWithChildren<LinkProps>): JSX.Element;
+  /** Helper method to resolve an Href object into a string. */
+  resolveHref: typeof resolveHref;
 }
 
 /**
@@ -44,10 +50,9 @@ export function Redirect({ href }: { href: Href }) {
  * @param props.asChild Forward props to child component. Useful for custom buttons.
  * @param props.children Child elements to render the content.
  */
-export const Link = React.forwardRef(ExpoRouterLink) as {
-  /** Helper method to resolve an Href object into a string. */
-  resolveHref: typeof resolveHref;
-} & React.ForwardRefExoticComponent<Props>;
+export const Link = React.forwardRef(
+  ExpoRouterLink
+) as unknown as LinkComponent;
 
 Link.resolveHref = resolveHref;
 
@@ -58,7 +63,7 @@ function ExpoRouterLink(
     // TODO: This does not prevent default on the anchor tag.
     asChild,
     ...rest
-  }: Props,
+  }: LinkProps,
   ref: React.ForwardedRef<Text>
 ) {
   const resolvedHref = React.useMemo(() => {

--- a/packages/expo-router/src/link/href.ts
+++ b/packages/expo-router/src/link/href.ts
@@ -1,11 +1,11 @@
 export type Href = string | HrefObject;
 
-export type HrefObject = {
+export interface HrefObject {
   /** Path representing the selected route `/[id]`. */
   pathname?: string;
   /** Query parameters for the path. */
   params?: Record<string, any>;
-};
+}
 
 /** Resolve an href object into a fully qualified, relative href. */
 export const resolveHref = (href: Href): string => {


### PR DESCRIPTION
# Motivation

Add typed routing for absolute paths to `<Link />`. Requires https://github.com/expo/expo/pull/21651 to work, but this can be merged independently.


# Execution

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
