### PR TITLE
feat: upgrade to TypeScript 5

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "lerna": "3.4.1",
     "patch-package": "^6.4.7",
     "prettier": "^2.2.1",
-    "typescript": "^4.9.5",
+    "typescript": "^5.0.0",
     "jest": "^29.4.3",
     "ts-jest": "^29.0.5",
     "expo-module-scripts": "^3.0.7"

--- a/packages/expo-router/src/link/stateOperations.ts
+++ b/packages/expo-router/src/link/stateOperations.ts
@@ -1,12 +1,25 @@
-import { InitialState, NavigationState } from "@react-navigation/native";
+import {
+  InitialState,
+  NavigationState,
+  ParamListBase,
+  getActionFromState,
+} from "@react-navigation/native";
 
 import { ResultState } from "../fork/getStateFromPath";
 
-export type ActionParams = {
-  params?: ActionParams;
+export type NavigateAction = Extract<
+  ReturnType<typeof getActionFromState>,
+  { type: "NAVIGATE" }
+> & {
+  payload: NavigateActionParams;
+};
+
+export type NavigateActionParams = {
+  params?: NavigateActionParams;
   path: string;
   initial: boolean;
   screen: string;
+  name?: string;
 };
 
 // Get the last state for a given target state (generated from a path).
@@ -95,19 +108,12 @@ export function getQualifiedStateForTopOfTargetState(
   return currentRoot;
 }
 
-type SubState = NavigationState & {
-  key?: string;
-  type: string;
-  routes?: { name: string; state?: SubState }[];
-  index?: number;
-};
-
 // Given the root state and a target state from `getStateFromPath`,
 // return the root state containing the highest target route matching the root state.
 // This can be used to determine what type of navigator action should be used.
-export function getEarliestMismatchedRoute(
-  rootState: SubState | undefined,
-  actionParams: ActionParams & { name?: string }
+export function getEarliestMismatchedRoute<T extends ParamListBase>(
+  rootState: NavigationState<T> | undefined,
+  actionParams: NavigateActionParams
 ): { name: string; params?: any; type?: string } | null {
   const actionName = actionParams.name ?? actionParams.screen;
   if (!rootState?.routes || rootState.index == null) {
@@ -126,7 +132,9 @@ export function getEarliestMismatchedRoute(
     }
 
     return getEarliestMismatchedRoute(
-      nextCurrentRoot.state,
+      // @react-navigation/native types this as NavigationState | Partial<NavigationState> | undefined
+      // In our usage, it's always a NavigationState | undefined
+      nextCurrentRoot.state as NavigationState<T> | undefined,
       actionParams.params
     );
   }

--- a/packages/expo-router/src/link/useLinkToPath.ts
+++ b/packages/expo-router/src/link/useLinkToPath.ts
@@ -14,6 +14,7 @@ import {
   getEarliestMismatchedRoute,
   getQualifiedStateForTopOfTargetState,
   isMovingToSiblingRoute,
+  NavigateAction,
 } from "./stateOperations";
 import { useLinkingContext } from "./useLinkingContext";
 
@@ -116,14 +117,9 @@ export function useLinkToPath() {
         // Then find the nearest mismatched route in the existing state.
         // Finally, use the correct navigator-based action to replace the nested screens.
         // NOTE(EvanBacon): A future version of this will involve splitting the navigation request so we replace as much as possible, then push the remaining screens to fulfill the request.
-        if (
-          event === "REPLACE" &&
-          action.type === "NAVIGATE" &&
-          isAbsoluteInitialRoute(action)
-        ) {
+        if (event === "REPLACE" && isAbsoluteInitialRoute(action)) {
           const earliest = getEarliestMismatchedRoute(
             rootState,
-            // @ts-expect-error
             action.payload
           );
           if (earliest) {
@@ -159,7 +155,7 @@ export function useLinkToPath() {
 /** @returns `true` if the action is moving to the first screen of all the navigators in the action. */
 export function isAbsoluteInitialRoute(
   action: ReturnType<typeof getActionFromState>
-) {
+): action is NavigateAction {
   if (action?.type !== "NAVIGATE") {
     return false;
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -15695,10 +15695,15 @@ typescript@^4.6.3:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.4.tgz#a2a3d2756c079abda241d75f149df9d561091e78"
   integrity sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==
 
-typescript@^4.9.4, typescript@^4.9.5:
+typescript@^4.9.4:
   version "4.9.5"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
   integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
+
+typescript@^5.0.0:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.0.2.tgz#891e1a90c5189d8506af64b9ef929fca99ba1ee5"
+  integrity sha512-wVORMBGO/FAs/++blGNeAVdbNKtIh1rbBL2EyQ1+J9lClJ93KiiKe8PmFIVdXhHcyv44SL9oglmfeSsndo0jRw==
 
 ua-parser-js@^0.7.30:
   version "0.7.32"


### PR DESCRIPTION
# Motivation

TypeScript 5 has been released https://devblogs.microsoft.com/typescript/announcing-typescript-5-0/

After upgrading the only breaking change appears type inference with the `getEarliestMismatchedRoute` function (which also had a stray `ts-expect-error`)  