### PR TITLE
stricter type for `useFocusEffect`

### DIFF
--- a/packages/expo-router/src/useFocusEffect.tsx
+++ b/packages/expo-router/src/useFocusEffect.tsx
@@ -15,11 +15,11 @@ type EffectCallback = () => undefined | void | (() => void);
  */
 export function useFocusEffect(
   effect: EffectCallback,
-  do_not_pass_a_second_prop?: any
+  do_not_pass_a_second_prop?: never
 ) {
   const navigation = useOptionalNavigation();
 
-  if (do_not_pass_a_second_prop !== undefined) {
+  if (do_not_pass_a_second_prop) {
     const message =
       "You passed a second argument to 'useFocusEffect', but it only accepts one argument. " +
       "If you want to pass a dependency array, you can use 'React.useCallback':\n\n" +

--- a/packages/expo-router/src/useFocusEffect.tsx
+++ b/packages/expo-router/src/useFocusEffect.tsx
@@ -19,7 +19,7 @@ export function useFocusEffect(
 ) {
   const navigation = useOptionalNavigation();
 
-  if (do_not_pass_a_second_prop) {
+  if (do_not_pass_a_second_prop !== undefined) {
     const message =
       "You passed a second argument to 'useFocusEffect', but it only accepts one argument. " +
       "If you want to pass a dependency array, you can use 'React.useCallback':\n\n" +


### PR DESCRIPTION
# Motivation

Currently if you pass a second argument to `useFocusEffect` you will not receive a type-level warning, but you will get a `console.error` at runtime. 

With this solution, developers will see a red squiggly in their code if they try to pass a second argument. 

# Execution

use `never | undefined` instead of `any | undefined`

# Test Plan

N / A