### PR TITLE
fix #362

### DIFF
--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- fix deep linking on native.
+
 ### 💡 Others
 
 ## [Mon, 20 Mar 2023 11:23:51 -0500](https://github.com/expo/router/commit/ebba591b2e1cc30279da1309a8a77ce044dc18b9)

--- a/packages/expo-router/src/fork/__tests__/__snapshots__/extractPathFromURL.test.ios.ts.snap
+++ b/packages/expo-router/src/fork/__tests__/__snapshots__/extractPathFromURL.test.ios.ts.snap
@@ -1,37 +1,81 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`extractExpoPathFromURL parses "custom://" 1`] = `""`;
+exports[`extractExpoPathFromURL Bare parses "custom://" 1`] = `""`;
 
-exports[`extractExpoPathFromURL parses "custom:///" 1`] = `""`;
+exports[`extractExpoPathFromURL Bare parses "custom:///" 1`] = `""`;
 
-exports[`extractExpoPathFromURL parses "custom:///?shouldBeEscaped=x%252By%2540xxx.com" 1`] = `"?shouldBeEscaped=x+y@xxx.com"`;
+exports[`extractExpoPathFromURL Bare parses "custom:///?shouldBeEscaped=x%252By%2540xxx.com" 1`] = `"?shouldBeEscaped=x+y@xxx.com"`;
 
-exports[`extractExpoPathFromURL parses "custom:///test/path?foo=bar" 1`] = `"test/path?foo=bar"`;
+exports[`extractExpoPathFromURL Bare parses "custom:///test/path?foo=bar" 1`] = `"test/path?foo=bar"`;
 
-exports[`extractExpoPathFromURL parses "custom://?hello=bar" 1`] = `"?hello=bar"`;
+exports[`extractExpoPathFromURL Bare parses "custom://?hello=bar" 1`] = `"?hello=bar"`;
 
-exports[`extractExpoPathFromURL parses "exp://127.0.0.1:19000/" 1`] = `""`;
+exports[`extractExpoPathFromURL Bare parses "exp://127.0.0.1:19000/" 1`] = `"127.0.0.1:19000/"`;
 
-exports[`extractExpoPathFromURL parses "exp://127.0.0.1:19000/--/test/path?query=param" 1`] = `"test/path?query=param"`;
+exports[`extractExpoPathFromURL Bare parses "exp://127.0.0.1:19000/--/test/path?query=param" 1`] = `"127.0.0.1:19000/--/test/path?query=param"`;
 
-exports[`extractExpoPathFromURL parses "exp://127.0.0.1:19000?query=param" 1`] = `"?query=param"`;
+exports[`extractExpoPathFromURL Bare parses "exp://127.0.0.1:19000/--/test/path?shouldBeEscaped=x%252By%2540xxx.com" 1`] = `"127.0.0.1:19000/--/test/path?shouldBeEscaped=x+y@xxx.com"`;
 
-exports[`extractExpoPathFromURL parses "exp://exp.host/@test/test/--/test/path" 1`] = `"test/path"`;
+exports[`extractExpoPathFromURL Bare parses "exp://127.0.0.1:19000/x?y=x%252By%2540xxx.com" 1`] = `"127.0.0.1:19000/x?y=x+y@xxx.com"`;
 
-exports[`extractExpoPathFromURL parses "exp://exp.host/@test/test/--/test/path/--/foobar" 1`] = `"test/path/--/foobar"`;
+exports[`extractExpoPathFromURL Bare parses "exp://127.0.0.1:19000?query=param" 1`] = `"127.0.0.1:19000?query=param"`;
 
-exports[`extractExpoPathFromURL parses "exp://exp.host/@test/test/--/test/path?query=param" 1`] = `"test/path?query=param"`;
+exports[`extractExpoPathFromURL Bare parses "exp://exp.host/@test/test/--/test/path" 1`] = `"exp.host/@test/test/--/test/path"`;
 
-exports[`extractExpoPathFromURL parses "https://example.com/test/path" 1`] = `"test/path"`;
+exports[`extractExpoPathFromURL Bare parses "exp://exp.host/@test/test/--/test/path/--/foobar" 1`] = `"exp.host/@test/test/--/test/path/--/foobar"`;
 
-exports[`extractExpoPathFromURL parses "https://example.com/test/path?missingQueryValue=" 1`] = `"test/path?missingQueryValue="`;
+exports[`extractExpoPathFromURL Bare parses "exp://exp.host/@test/test/--/test/path?query=param" 1`] = `"exp.host/@test/test/--/test/path?query=param"`;
 
-exports[`extractExpoPathFromURL parses "https://example.com/test/path?query=do+not+escape" 1`] = `"test/path?query=do not escape"`;
+exports[`extractExpoPathFromURL Bare parses "https://example.com/test/path" 1`] = `"test/path"`;
 
-exports[`extractExpoPathFromURL parses "https://example.com/test/path?query=param" 1`] = `"test/path?query=param"`;
+exports[`extractExpoPathFromURL Bare parses "https://example.com/test/path?missingQueryValue=" 1`] = `"test/path?missingQueryValue="`;
 
-exports[`extractExpoPathFromURL parses "https://example.com:8000/test/path" 1`] = `"test/path"`;
+exports[`extractExpoPathFromURL Bare parses "https://example.com/test/path?query=do+not+escape" 1`] = `"test/path?query=do+not+escape"`;
 
-exports[`extractExpoPathFromURL parses "https://example.com:8000/test/path+with+plus" 1`] = `"with+plus"`;
+exports[`extractExpoPathFromURL Bare parses "https://example.com/test/path?query=param" 1`] = `"test/path?query=param"`;
 
-exports[`extractExpoPathFromURL parses "invalid" 1`] = `"invalid"`;
+exports[`extractExpoPathFromURL Bare parses "https://example.com:8000/test/path" 1`] = `"test/path"`;
+
+exports[`extractExpoPathFromURL Bare parses "https://example.com:8000/test/path+with+plus" 1`] = `"test/path+with+plus"`;
+
+exports[`extractExpoPathFromURL Bare parses "invalid" 1`] = `"invalid"`;
+
+exports[`extractExpoPathFromURL Expo Go parses "custom://" 1`] = `""`;
+
+exports[`extractExpoPathFromURL Expo Go parses "custom:///" 1`] = `""`;
+
+exports[`extractExpoPathFromURL Expo Go parses "custom:///?shouldBeEscaped=x%252By%2540xxx.com" 1`] = `"?shouldBeEscaped=x+y@xxx.com"`;
+
+exports[`extractExpoPathFromURL Expo Go parses "custom:///test/path?foo=bar" 1`] = `"test/path?foo=bar"`;
+
+exports[`extractExpoPathFromURL Expo Go parses "custom://?hello=bar" 1`] = `"?hello=bar"`;
+
+exports[`extractExpoPathFromURL Expo Go parses "exp://127.0.0.1:19000/" 1`] = `""`;
+
+exports[`extractExpoPathFromURL Expo Go parses "exp://127.0.0.1:19000/--/test/path?query=param" 1`] = `"test/path?query=param"`;
+
+exports[`extractExpoPathFromURL Expo Go parses "exp://127.0.0.1:19000/--/test/path?shouldBeEscaped=x%252By%2540xxx.com" 1`] = `"test/path?shouldBeEscaped=x+y@xxx.com"`;
+
+exports[`extractExpoPathFromURL Expo Go parses "exp://127.0.0.1:19000/x?y=x%252By%2540xxx.com" 1`] = `"x?y=x+y@xxx.com"`;
+
+exports[`extractExpoPathFromURL Expo Go parses "exp://127.0.0.1:19000?query=param" 1`] = `"?query=param"`;
+
+exports[`extractExpoPathFromURL Expo Go parses "exp://exp.host/@test/test/--/test/path" 1`] = `"test/path"`;
+
+exports[`extractExpoPathFromURL Expo Go parses "exp://exp.host/@test/test/--/test/path/--/foobar" 1`] = `"test/path/--/foobar"`;
+
+exports[`extractExpoPathFromURL Expo Go parses "exp://exp.host/@test/test/--/test/path?query=param" 1`] = `"test/path?query=param"`;
+
+exports[`extractExpoPathFromURL Expo Go parses "https://example.com/test/path" 1`] = `"test/path"`;
+
+exports[`extractExpoPathFromURL Expo Go parses "https://example.com/test/path?missingQueryValue=" 1`] = `"test/path?missingQueryValue="`;
+
+exports[`extractExpoPathFromURL Expo Go parses "https://example.com/test/path?query=do+not+escape" 1`] = `"test/path?query=do+not+escape"`;
+
+exports[`extractExpoPathFromURL Expo Go parses "https://example.com/test/path?query=param" 1`] = `"test/path?query=param"`;
+
+exports[`extractExpoPathFromURL Expo Go parses "https://example.com:8000/test/path" 1`] = `"test/path"`;
+
+exports[`extractExpoPathFromURL Expo Go parses "https://example.com:8000/test/path+with+plus" 1`] = `"test/path+with+plus"`;
+
+exports[`extractExpoPathFromURL Expo Go parses "invalid" 1`] = `"invalid"`;

--- a/packages/expo-router/src/fork/__tests__/extractPathFromURL.test.ios.ts
+++ b/packages/expo-router/src/fork/__tests__/extractPathFromURL.test.ios.ts
@@ -48,24 +48,17 @@ describe(extractExpoPathFromURL, () => {
       });
     });
   }
-  it(`decodes query params`, () => {
+  it(`decodes query params in bare`, () => {
     Constants.executionEnvironment = ExecutionEnvironment.Bare;
-    expect(extractExpoPathFromURL(`custom:///?x=x%252By%2540xxx.com`)).toEqual(
-      "?x=x+y@xxx.com"
-    );
-
+    expect(extractExpoPathFromURL(`custom:///?x=%20%2B%2F`)).toEqual("?x= +/");
+  });
+  it(`decodes query params in Expo Go`, () => {
     Constants.executionEnvironment = ExecutionEnvironment.StoreClient;
-    expect(extractExpoPathFromURL(`custom:///?x=x%252By%2540xxx.com`)).toEqual(
-      "?x=x+y@xxx.com"
-    );
+    expect(extractExpoPathFromURL(`custom:///?x=%20%2B%2F`)).toEqual("?x= +/");
     expect(
-      extractExpoPathFromURL(
-        `exp://127.0.0.1:19000/--/test/path?x=x%252By%2540xxx.com`
-      )
-    ).toEqual("test/path?x=x+y@xxx.com");
-    expect(extractExpoPathFromURL(`exp://x?y=x%252By%2540xxx.com`)).toEqual(
-      "?y=x+y@xxx.com"
-    );
+      extractExpoPathFromURL(`exp://127.0.0.1:19000/--/test/path?x=%20%2B%2F`)
+    ).toEqual("test/path?x= +/");
+    expect(extractExpoPathFromURL(`exp://x?y=%20%2B%2F`)).toEqual("?y= +/");
   });
 
   it(`only handles Expo Go URLs in Expo Go`, () => {

--- a/packages/expo-router/src/fork/__tests__/extractPathFromURL.test.ios.ts
+++ b/packages/expo-router/src/fork/__tests__/extractPathFromURL.test.ios.ts
@@ -9,38 +9,71 @@ describe(extractExpoPathFromURL, () => {
     Constants.executionEnvironment = originalExecutionEnv;
   });
 
-  test.each<string>([
-    "exp://127.0.0.1:19000/",
-    "exp://127.0.0.1:19000/--/test/path?query=param",
-    "exp://127.0.0.1:19000?query=param",
-    "exp://exp.host/@test/test/--/test/path?query=param",
-    "exp://exp.host/@test/test/--/test/path",
-    "exp://exp.host/@test/test/--/test/path/--/foobar",
-    "https://example.com/test/path?query=param",
-    "https://example.com/test/path",
-    "https://example.com:8000/test/path",
-    "https://example.com:8000/test/path+with+plus",
-    "https://example.com/test/path?query=do+not+escape",
-    "https://example.com/test/path?missingQueryValue=",
-    "custom:///?shouldBeEscaped=x%252By%2540xxx.com",
-    "custom:///test/path?foo=bar",
-    "custom:///",
-    "custom://",
-    "custom://?hello=bar",
-    "invalid",
-  ])(`parses %p`, (url) => {
-    Constants.executionEnvironment = ExecutionEnvironment.StoreClient;
+  for (const [name, exenv] of [
+    ["Expo Go", ExecutionEnvironment.StoreClient],
+    ["Bare", ExecutionEnvironment.Bare],
+  ] as const) {
+    describe(name, () => {
+      test.each<string>([
+        "exp://127.0.0.1:19000/",
+        "exp://127.0.0.1:19000/--/test/path?query=param",
+        "exp://127.0.0.1:19000/--/test/path?shouldBeEscaped=x%252By%2540xxx.com",
+        "exp://127.0.0.1:19000/x?y=x%252By%2540xxx.com",
+        "exp://127.0.0.1:19000?query=param",
+        "exp://exp.host/@test/test/--/test/path?query=param",
+        "exp://exp.host/@test/test/--/test/path",
+        "exp://exp.host/@test/test/--/test/path/--/foobar",
+        "https://example.com/test/path?query=param",
+        "https://example.com/test/path",
+        "https://example.com:8000/test/path",
+        "https://example.com:8000/test/path+with+plus",
+        "https://example.com/test/path?query=do+not+escape",
+        "https://example.com/test/path?missingQueryValue=",
+        "custom:///?shouldBeEscaped=x%252By%2540xxx.com",
+        "custom:///test/path?foo=bar",
+        "custom:///",
+        "custom://",
+        "custom://?hello=bar",
+        "invalid",
+      ])(`parses %p`, (url) => {
+        Constants.executionEnvironment = exenv;
 
-    const res = extractExpoPathFromURL(url);
-    expect(res).toMatchSnapshot();
-    // Ensure the Expo Go handling never breaks
-    expect(res).not.toMatch(/^--\//);
+        const res = extractExpoPathFromURL(url);
+        expect(res).toMatchSnapshot();
+
+        if (exenv === ExecutionEnvironment.StoreClient) {
+          // Ensure the Expo Go handling never breaks
+          expect(res).not.toMatch(/^--\//);
+        }
+      });
+    });
+  }
+  it(`decodes query params`, () => {
+    Constants.executionEnvironment = ExecutionEnvironment.Bare;
+    expect(extractExpoPathFromURL(`custom:///?x=x%252By%2540xxx.com`)).toEqual(
+      "?x=x+y@xxx.com"
+    );
+
+    Constants.executionEnvironment = ExecutionEnvironment.StoreClient;
+    expect(extractExpoPathFromURL(`custom:///?x=x%252By%2540xxx.com`)).toEqual(
+      "?x=x+y@xxx.com"
+    );
+    expect(
+      extractExpoPathFromURL(
+        `exp://127.0.0.1:19000/--/test/path?x=x%252By%2540xxx.com`
+      )
+    ).toEqual("test/path?x=x+y@xxx.com");
+    expect(extractExpoPathFromURL(`exp://x?y=x%252By%2540xxx.com`)).toEqual(
+      "?y=x+y@xxx.com"
+    );
   });
 
   it(`only handles Expo Go URLs in Expo Go`, () => {
     Constants.executionEnvironment = ExecutionEnvironment.Bare;
 
     const res = extractExpoPathFromURL("exp://127.0.0.1:19000/--/test");
-    expect(res).toEqual("--/test");
+    // This should look mostly broken, but it's the best we can do
+    // when someone uses this format outside of Expo Go.
+    expect(res).toEqual("127.0.0.1:19000/--/test");
   });
 });

--- a/packages/expo-router/src/fork/extractPathFromURL.ts
+++ b/packages/expo-router/src/fork/extractPathFromURL.ts
@@ -1,22 +1,72 @@
 import Constants, { ExecutionEnvironment } from "expo-constants";
 import * as Linking from "expo-linking";
+import URL from "url-parse";
 
 // This is only run on native.
-export function extractExpoPathFromURL(url: string) {
-  // Handle special URLs used in Expo Go: `/--/pathname` -> `pathname`
-  if (Constants.executionEnvironment === ExecutionEnvironment.StoreClient) {
-    const pathname = url.match(/exps?:\/\/.*?\/--\/(.*)/)?.[1];
-    if (pathname) {
-      return pathname;
-    }
-    // Fallback on default behavior
+function extractExactPathFromURL(url: string) {
+  if (
+    // If a universal link / app link / web URL is used, we should use the path
+    // from the URL, while stripping the origin.
+    url.match(/^https?:\/\//)
+  ) {
+    const { origin, href } = new URL(url);
+    return href.replace(origin, "");
   }
 
-  const res = Linking.parse(url);
-  const qs = !res.queryParams
+  // Handle special URLs used in Expo Go: `/--/pathname` -> `pathname`
+  if (
+    Constants.executionEnvironment === ExecutionEnvironment.StoreClient &&
+    // while not exhaustive, `exp` and `exps` are the only two schemes which
+    // are passed through to other apps in Expo Go.
+    url.match(/^exp(s)?:\/\//)
+  ) {
+    const pathname = url.match(/exps?:\/\/.*?\/--\/(.*)/)?.[1];
+    if (pathname) {
+      return fromDeepLink("a://" + pathname);
+    }
+
+    const res = Linking.parse(url);
+    const qs = !res.queryParams
+      ? ""
+      : Object.entries(res.queryParams)
+          .map(([k, v]) => `${k}=${v}`)
+          .join("&");
+    return (res.path || "") + (qs ? "?" + qs : "");
+  }
+
+  // TODO: Support dev client URLs
+
+  return fromDeepLink(url);
+}
+
+function fromDeepLink(url: string) {
+  // This is for all standard deep links, e.g. `foobar://` where everything
+  // after the `://` is the path.
+  const res = new URL(url, true);
+  const qs = !res.query
     ? ""
-    : Object.entries(res.queryParams)
-        .map(([k, v]) => `${k}=${v}`)
+    : Object.entries(res.query as Record<string, string>)
+        .map(([k, v]) => `${k}=${decodeURIComponent(v)}`)
         .join("&");
-  return (res.path || "") + (qs ? "?" + qs : "");
+
+  let results = "";
+
+  if (res.host) {
+    results += res.host;
+  }
+
+  if (res.pathname) {
+    results += res.pathname;
+  }
+
+  if (qs) {
+    results += "?" + qs;
+  }
+
+  return results;
+}
+
+export function extractExpoPathFromURL(url: string) {
+  // TODO: We should get rid of this, dropping specificities is not good
+  return extractExactPathFromURL(url).replace(/^\//, "");
 }


### PR DESCRIPTION
# Motivation

- fix https://github.com/expo/router/issues/362
- replaces https://github.com/expo/router/pull/371 as the issue is pressing

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# Execution

- Handle web links first based on if the link starts with `http` or `https`.
- Only parse Expo links if the process is running in Expo Go and the protocol matches `exp` or `exps`.
- Ensure the parameters are escaped uniformly

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

- added more unit tests

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
