### PR TITLE
Add more depth to vercel.json

### DIFF
--- a/docs/docs/guides/hosting.md
+++ b/docs/docs/guides/hosting.md
@@ -14,7 +14,7 @@ Create a `./public/_redirects` (`./web/_redirects` with Expo Webpack) file and a
 
 ## Vercel
 
-Create a `./vercel.json` inside your ./dist folder (Important: Metro bundler will override anything inside the ./dist folder each time you re-bundle for web) and add the following:
+Create a `./public/vercel.json` (contents of the root `public` folder are copied into the output `dist` folder) and add the following:
 
 ```json
 {

--- a/docs/docs/guides/hosting.md
+++ b/docs/docs/guides/hosting.md
@@ -14,7 +14,7 @@ Create a `./public/_redirects` (`./web/_redirects` with Expo Webpack) file and a
 
 ## Vercel
 
-Create a `./vercel.json` and add the following:
+Create a `./vercel.json` inside your ./dist folder (Important: Metro bundler will override anything inside the ./dist folder each time you re-bundle for web) and add the following:
 
 ```json
 {


### PR DESCRIPTION
Unfortunately, the file must be placed manually inside the ./dist folder and gets overwritten by Metro each time ...

# Motivation

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# Execution


I was working on this issue for 2 days and eventually found this out  🥳. Everything works now on my side. 
p.s. it is def. not the best documentation. How could it be made awesome: Fernando does an incredible job at "over-communicating" all of his projects, and him being the author of Solitio...  team up for this endeavour?


# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
