### PR TITLE
fix(router): improve "going back" from an unmatched route.

### DIFF
--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Improve "going back" from an unmatched route.
+
 ### 💡 Others
 
 ## [Mon, 27 Mar 2023 17:42:06 -0500](https://github.com/expo/router/commit/52deb844568548eb6be0a217b7f0c7cbdf97ba89)

--- a/packages/expo-router/src/views/Unmatched.tsx
+++ b/packages/expo-router/src/views/Unmatched.tsx
@@ -4,10 +4,12 @@ import React from "react";
 
 import { usePathname } from "../LocationProvider";
 import { Link } from "../link/Link";
+import { useRouter } from "../link/useRouter";
 import { useNavigation } from "../useNavigation";
 
 /** Default screen for unmatched routes. */
 export function Unmatched() {
+  const router = useRouter();
   const navigation = useNavigation();
   const pathname = usePathname();
   const url = createURL(pathname);
@@ -33,9 +35,18 @@ export function Unmatched() {
         style={styles.subtitle}
       >
         Page could not be found.{" "}
-        <Link href="/" replace style={styles.link}>
+        <Text
+          onPress={() => {
+            if (navigation.canGoBack()) {
+              navigation.goBack();
+            } else {
+              router.replace("/");
+            }
+          }}
+          style={styles.link}
+        >
           Go back.
-        </Link>
+        </Text>
       </Text>
 
       <Link href={pathname} replace style={styles.link}>


### PR DESCRIPTION
# Motivation

This PR improves the "go back" behavior when pushing an unsupported screen in development. Historically it has only been optimized for landing on the unmatched route.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# Execution

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
