### PR TITLE
fix typo on authentication guide

### DIFF
--- a/docs/docs/guides/auth.md
+++ b/docs/docs/guides/auth.md
@@ -84,7 +84,7 @@ export default function Root() {
 }
 ```
 
-Now we can create our `(auth)` group which is protected, this screen can toggle the authentication using `signIn()`.
+Now we can create our `(auth)` group which is unprotected, this screen can toggle the authentication using `signIn()`.
 
 ```js title=app/(auth)/sign-in.js
 import { Text, View } from "react-native";


### PR DESCRIPTION
The `(auth)` group is supposed to be unprotected, but the doc says protected

# Motivation

Documentation improvement

# Execution

Not applicable

# Test Plan

Not applicable