### PR TITLE
feat(router): add hack to temporarily support `expo-development-client`.

### DIFF
--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Add hack to temporarily support `expo-development-client`.
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/expo-router/src/fork/__tests__/__snapshots__/extractPathFromURL.test.ios.ts.snap
+++ b/packages/expo-router/src/fork/__tests__/__snapshots__/extractPathFromURL.test.ios.ts.snap
@@ -1,5 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`extractExpoPathFromURL Bare parses "app.bacon.expo://expo-development-client" 1`] = `""`;
+
 exports[`extractExpoPathFromURL Bare parses "custom://" 1`] = `""`;
 
 exports[`extractExpoPathFromURL Bare parses "custom:///" 1`] = `""`;
@@ -48,6 +50,14 @@ exports[`extractExpoPathFromURL Bare parses "https://example.com:8000/test/path+
 
 exports[`extractExpoPathFromURL Bare parses "invalid" 1`] = `"invalid"`;
 
+exports[`extractExpoPathFromURL Bare parses "scheme://expo-development-client/?url=acme://foo/bar?query=param&query2=param2" 1`] = `"foo/bar?query=param"`;
+
+exports[`extractExpoPathFromURL Bare parses "scheme://expo-development-client/?url=http%3A%2F%2Flocalhost%3A8081%2Fexample%2Fpath" 1`] = `"example/path"`;
+
+exports[`extractExpoPathFromURL Bare parses "scheme://expo-development-client/?url=http://acme.com/foo/bar?query=param" 1`] = `"foo/bar?query=param"`;
+
+exports[`extractExpoPathFromURL Expo Go parses "app.bacon.expo://expo-development-client" 1`] = `""`;
+
 exports[`extractExpoPathFromURL Expo Go parses "custom://" 1`] = `""`;
 
 exports[`extractExpoPathFromURL Expo Go parses "custom:///" 1`] = `""`;
@@ -95,3 +105,9 @@ exports[`extractExpoPathFromURL Expo Go parses "https://example.com:8000/test/pa
 exports[`extractExpoPathFromURL Expo Go parses "https://example.com:8000/test/path+with+plus" 1`] = `"test/path+with+plus"`;
 
 exports[`extractExpoPathFromURL Expo Go parses "invalid" 1`] = `"invalid"`;
+
+exports[`extractExpoPathFromURL Expo Go parses "scheme://expo-development-client/?url=acme://foo/bar?query=param&query2=param2" 1`] = `"foo/bar?query=param"`;
+
+exports[`extractExpoPathFromURL Expo Go parses "scheme://expo-development-client/?url=http%3A%2F%2Flocalhost%3A8081%2Fexample%2Fpath" 1`] = `"example/path"`;
+
+exports[`extractExpoPathFromURL Expo Go parses "scheme://expo-development-client/?url=http://acme.com/foo/bar?query=param" 1`] = `"foo/bar?query=param"`;

--- a/packages/expo-router/src/fork/__tests__/extractPathFromURL.test.ios.ts
+++ b/packages/expo-router/src/fork/__tests__/extractPathFromURL.test.ios.ts
@@ -15,6 +15,10 @@ describe(extractExpoPathFromURL, () => {
   ] as const) {
     describe(name, () => {
       test.each<string>([
+        "scheme://expo-development-client/?url=http%3A%2F%2Flocalhost%3A8081%2Fexample%2Fpath",
+        "scheme://expo-development-client/?url=http://acme.com/foo/bar?query=param",
+        "scheme://expo-development-client/?url=acme://foo/bar?query=param&query2=param2",
+        "app.bacon.expo://expo-development-client",
         "exp://127.0.0.1:19000/",
         "exp://127.0.0.1:19000/--/test/path?query=param",
         "exp://127.0.0.1:19000/--/test/path?shouldBeEscaped=x%252By%2540xxx.com",


### PR DESCRIPTION
# Motivation

- development client doesn't have any plan or story around URL handling, this is a best-effort attempt to support projects that use `expo-development-client`.

# Execution

- If a deep link, used outside of Expo Go, contains the hostname `expo-development-client`, then we extract the `url` query parameter, decode it, then parse it as the expected deep link.
- This effectively means `/--/`, and pathname, and any additional query parameters outside of the url query parameter are ignored.


- fix https://github.com/expo/router/issues/457