### PR TITLE
drop __filename and __dirname mocks

### DIFF
--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### 🛠 Breaking changes
 
+- Drop (undocumented) mocks for `__dirname` and `__filename` when transpiling client code.
+
 ### 🎉 New features
 
 ### 🐛 Bug fixes

--- a/packages/expo-router/babel.js
+++ b/packages/expo-router/babel.js
@@ -83,30 +83,11 @@ function getExpoRouterAppRoot(projectRoot) {
 
 module.exports = function (api) {
   const { types: t } = api;
-  const getRelPath = (state) =>
-    "./" + nodePath.relative(state.file.opts.root, state.filename);
 
   const platform = api.caller((caller) => caller?.platform);
   return {
     name: "expo-router",
     visitor: {
-      // Add support for Node.js __filename
-      Identifier(path, state) {
-        if (path.node.name === "__filename") {
-          path.replaceWith(
-            t.stringLiteral(
-              // `/index.js` is the value used by Webpack.
-              getRelPath(state)
-            )
-          );
-        }
-        // Add support for Node.js `__dirname`.
-        // This static value comes from Webpack somewhere.
-        if (path.node.name === "__dirname") {
-          path.replaceWith(t.stringLiteral("/"));
-        }
-      },
-
       // Convert `process.env.EXPO_ROUTER_APP_ROOT` to a string literal
       MemberExpression(path, state) {
         if (


### PR DESCRIPTION
# Motivation

Unclear how these ended up in the final release, we should drop them from client mocks for now. Can add them back later in the transformer if we need them.


