### PR TITLE
Malformed URI decoding error

### DIFF
--- a/packages/expo-router/src/__tests__/LocationProvider.test.node.ts
+++ b/packages/expo-router/src/__tests__/LocationProvider.test.node.ts
@@ -27,6 +27,18 @@ describe(getNormalizedStatePath, () => {
       },
     });
   });
+
+  it(`should not throw an error when path contains a % sign`, () => {
+    expect(
+      getNormalizedStatePath({
+        path: "/foo/100%%20bar",
+        params: {},
+      })
+    ).toEqual({
+      segments: ["foo", "100% bar"],
+      params: {},
+    });
+  });
 });
 
 describe(compareUrlSearchParams, () => {


### PR DESCRIPTION
# Motivation

On a earlier version (1.0 AFAIK) I had a route containing the % sign, the URLs worked. On the latest version they no longer do. The error is `URIError: Malformed decodeURI input` for the `LocationProvider`.

# Execution

This is currently not a fix but a test to reproduce the issue.

# Test Plan

Run the automated tests.
