### PR TITLE
Added installation instruction for @react-navigation/drawer

### DIFF
--- a/docs/docs/migration/react-navigation/drawer-navigator.md
+++ b/docs/docs/migration/react-navigation/drawer-navigator.md
@@ -7,7 +7,7 @@ To use the React Navigation [drawer navigator](https://reactnavigation.org/docs/
 ## Installation
 
 Follow the [installation guide](https://reactnavigation.org/docs/drawer-navigator#installation) for Drawer Navigator.
-
+- Install `@react-navigation/drawer`: `npx expo install @react-navigation/drawer`
 - Ensure `react-native-reanimated` is correctly configured in the `babel.config.js` file.
 - Changes to the `babel.config.js` require a clean babel cache to be applied: `npx expo start --clear`.
 


### PR DESCRIPTION
# Motivation

Noticed that the @react-navigation/drawer is missing in this version `"expo-router": "^1.2.0"` so I added an installation instruction for it.


