### PR TITLE
fix: Convert react-native-web types to an ambient module

### DIFF
--- a/docs/docs/lab/typescript.md
+++ b/docs/docs/lab/typescript.md
@@ -1,0 +1,73 @@
+---
+title: TypeScript
+---
+
+> This guide refers to upcoming Expo Router features, all of which are experimental.
+
+Expo Router provides an integrated TypeScript experience. To get started:
+
+- Install TypeScript either by `yarn -D typescript` or `npm i -D typescript`
+- Run `npx tsc init` or `yarn tsc init` to initialise TypeScript
+- Set the environment variable `EXPO_USE_TYPED_ROUTER=true`
+
+When enabled, Expo Router will automatically adjust your environment to ensure Expo Router types are picked up by the TypeScript compiler.
+
+> If `EXPO_USE_TYPED_ROUTER` is removed, Expo Router will remove the changes it made
+
+## Statically Typed Links
+
+Expo Router will generate a link definition in `.expo/types` that contains information about existing routes in your application. This overrides Expo Router's generic `Href<T>` definition with a personalised declaration.
+
+Components and functions that use `Href<T>` will now by statically typed and have a much stricter definition. For example:
+
+```
+// ✅
+<Link href="/about" />
+// ✅
+<Link href="/user/1" />
+// ✅
+<Link href={`/user/${id}`} />
+// ✅
+<Link href={('/user' + id) as Href} />
+
+// ❌ TypeScript errors if href is not a valid route
+<Link href="/usser/1" />
+```
+
+For dynamic routes, Href's need to be objects and their parameters are strictly typed
+
+```
+// ✅
+<Link href={{ pathname: "/user/[id]", params: { id: 1 }}} />
+
+
+// ❌ TypeScript errors as href is valid, but it should be a HrefObject with params
+<Link href="/user/[id]" />
+// ❌ TypeScript errors as params contains invalid keys
+<Link href={{ pathname: "/user/[id]", params: { _id: 1 }}} />
+// ❌ TypeScript errors as params contains unknown keys
+<Link href={{ pathname: "/user/[id]", params: { id: 1, id2: 2 }}} />
+```
+
+## Changes made to environment
+
+The `includes` field of your `tsconfig.json` will be updated to include `expo-env.d.ts` and a hidden `.expo` folder. These entries are required and should not be removed.
+
+The generated `expo-env.d.ts` should not be removed or changed at any time. It should not be committed and should be ignored by version control (e.g. inside your .gitignore file).
+
+### Global Types
+
+Expo Router makes the following changes to your TypeScript environment.
+
+- Sets `process.env.NODE_ENV = "development" | "production" | "test"`
+- Allows the importing of `.[css|sass|scss]` files
+- Sets the exports of `*.module.[css|sass|scss]` to be `Record<string, string`
+- Add types for Metro's `require.context`
+
+### React Native Web
+
+Using [Declaration Merging](https://www.typescriptlang.org/docs/handbook/declaration-merging.html), Expo Router adds additional types for React Native Web.
+
+- Add additional web-only styles for `ViewStyle/TextStyle/ImageStyle`
+- Add `tabIndex`/`accessibilityLevel`/`lang` to `TextProps`
+- Add `hovered` to Pressable's `children` and `style` state callback function

--- a/packages/expo-router/types/index.d.ts
+++ b/packages/expo-router/types/index.d.ts
@@ -1,0 +1,3 @@
+/// <reference types="./global" />
+/// <reference types="./react-native-web" />
+/// <reference types="./metro-require" />

--- a/packages/expo-router/types/react-native-web.d.ts
+++ b/packages/expo-router/types/react-native-web.d.ts
@@ -1,16 +1,15 @@
+import "react-native";
+
 declare module "react-native" {
-  export * from "react-native/types";
-
-  import * as RN from "react-native/types";
-
+  import { StyleProp } from "react-native";
   /**
    * View
    */
-  export interface ViewProps extends RN.ViewProps {
+  interface ViewProps {
     className?: string;
   }
 
-  type CommonWebStyle = {
+  interface ViewStyle {
     /** @platform web */
     backdropFilter?: string;
     /** @platform web */
@@ -117,14 +116,12 @@ declare module "react-native" {
     willChange?: string;
     /** @platform web */
     position?: "static" | "relative" | "absolute" | "fixed" | "sticky";
-  };
-
-  export interface ViewStyle extends RN.ViewStyle, CommonWebStyle {}
+  }
 
   /**
    * Text
    */
-  export interface TextProps extends RN.TextProps {
+  interface TextProps {
     className?: string;
     style?: RN.StyleProp<TextStyle>;
     /** @platform web */
@@ -135,7 +132,113 @@ declare module "react-native" {
     lang?: string;
   }
 
-  export interface TextStyle extends RN.TextStyle, CommonWebStyle {
+  interface TextStyle {
+    /** @platform web */
+    backdropFilter?: string;
+    /** @platform web */
+    animationDelay?: string;
+    /** @platform web */
+    animationDirection?: string;
+    /** @platform web */
+    animationDuration?: string;
+    /** @platform web */
+    animationFillMode?: string;
+    /** @platform web */
+    animationName?: string | any[];
+    /** @platform web */
+    animationIterationCount?: number | "infinite";
+    /** @platform web */
+    animationPlayState?: string;
+    /** @platform web */
+    animationTimingFunction?: string;
+    /** @platform web */
+    backgroundAttachment?: string;
+    /** @platform web */
+    backgroundBlendMode?: string;
+    /** @platform web */
+    backgroundClip?: string;
+    /** @platform web */
+    backgroundImage?: string;
+    /** @platform web */
+    backgroundOrigin?: "border-box" | "content-box" | "padding-box";
+    /** @platform web */
+    backgroundPosition?: string;
+    /** @platform web */
+    backgroundRepeat?: string;
+    /** @platform web */
+    backgroundSize?: string;
+    /** @platform web */
+    boxShadow?: string;
+    /** @platform web */
+    boxSizing?: string;
+    /** @platform web */
+    clip?: string;
+    /** @platform web */
+    cursor?: string;
+    /** @platform web */
+    filter?: string;
+    /** @platform web */
+    gridAutoColumns?: string;
+    /** @platform web */
+    gridAutoFlow?: string;
+    /** @platform web */
+    gridAutoRows?: string;
+    /** @platform web */
+    gridColumnEnd?: string;
+    /** @platform web */
+    gridColumnGap?: string;
+    /** @platform web */
+    gridColumnStart?: string;
+    /** @platform web */
+    gridRowEnd?: string;
+    /** @platform web */
+    gridRowGap?: string;
+    /** @platform web */
+    gridRowStart?: string;
+    /** @platform web */
+    gridTemplateColumns?: string;
+    /** @platform web */
+    gridTemplateRows?: string;
+    /** @platform web */
+    gridTemplateAreas?: string;
+    /** @platform web */
+    outline?: string;
+    /** @platform web */
+    outlineColor?: string;
+    /** @platform web */
+    overflowX?: string;
+    /** @platform web */
+    overflowY?: string;
+    /** @platform web */
+    overscrollBehavior?: "auto" | "contain" | "none";
+    /** @platform web */
+    overscrollBehaviorX?: "auto" | "contain" | "none";
+    /** @platform web */
+    overscrollBehaviorY?: "auto" | "contain" | "none";
+    /** @platform web */
+    perspective?: string;
+    /** @platform web */
+    perspectiveOrigin?: string;
+    /** @platform web */
+    touchAction?: string;
+    /** @platform web */
+    transformOrigin?: string;
+    /** @platform web */
+    transitionDelay?: string;
+    /** @platform web */
+    transitionDuration?: string;
+    /** @platform web */
+    transitionProperty?: string;
+    /** @platform web */
+    transitionTimingFunction?: string;
+    /** @platform web */
+    userSelect?: string;
+    /** @platform web */
+    visibility?: string;
+    /** @platform web */
+    willChange?: string;
+    /** @platform web */
+    position?: "static" | "relative" | "absolute" | "fixed" | "sticky";
     /** @platform web */
     fontFeatureSettings?: string;
     /** @platform web */
@@ -155,42 +258,42 @@ declare module "react-native" {
   /**
    * Pressable
    */
-  export interface PressableStateCallbackType {
+  interface PressableStateCallbackType {
     readonly pressed: boolean;
+    readonly hovered: boolean;
   }
 
-  export interface PressableProps extends Omit<RN.PressableProps, "style"> {
+  interface PressableProps {
     children?:
       | React.ReactNode
       | ((state: PressableStateCallbackType) => React.ReactNode)
       | undefined;
     style?:
-      | RN.StyleProp<ViewStyle>
-      | ((state: PressableStateCallbackType) => RN.StyleProp<ViewStyle>);
+      | StyleProp<ViewStyle>
+      | ((state: PressableStateCallbackType) => StyleProp<ViewStyle>);
   }
 
-  export const Pressable: React.ForwardRefExoticComponent<
-    PressableProps & React.RefAttributes<RN.View>
-  >;
+  // export const Pressable: React.ForwardRefExoticComponent<
+  //   PressableProps & React.RefAttributes<RN.View>
+  // >;
 
-  export interface FlatListProps<ItemT> extends RN.VirtualizedListProps<ItemT> {
+  interface FlatListProps {
     className?: string;
   }
 
-  export interface ImagePropsBase extends RN.ImagePropsBase {
+  interface ImagePropsBase {
     className?: string;
   }
 
-  export interface SwitchProps extends RN.SwitchProps {
+  interface SwitchProps {
     className?: string;
   }
 
-  export interface InputAccessoryViewProps extends RN.InputAccessoryViewProps {
+  interface InputAccessoryViewProps {
     className?: string;
   }
 
-  export interface TouchableWithoutFeedbackProps
-    extends RN.TouchableWithoutFeedbackProps {
+  interface TouchableWithoutFeedbackProps {
     className?: string;
   }
 }


### PR DESCRIPTION
# Motivation

Converts the RNW types to an ambient module.

`expo-env.d.ts` needs to be updated to `/// <reference types="expo-router/types" />`. This avoids an export conflict with the types defined in the `types` field from the `package.json`

You still need to add `expo-env.d.ts` to your include, but you need to ensure your other .ts files are also included.

eg `include: ['./expo-env.d.ts', './app/**/*']`