### PR TITLE
feat: cssInterop jsxImportSource

### DIFF
--- a/packages/expo-router/jsx-dev-runtime/package.json
+++ b/packages/expo-router/jsx-dev-runtime/package.json
@@ -1,0 +1,3 @@
+{
+  "main": "../src/css-interop/jsx-dev-runtime"
+}

--- a/packages/expo-router/jsx-runtime/package.json
+++ b/packages/expo-router/jsx-runtime/package.json
@@ -1,0 +1,3 @@
+{
+  "main": "../src/css-interop/jsx-runtime"
+}

--- a/packages/expo-router/src/css-interop/css-interop.ts
+++ b/packages/expo-router/src/css-interop/css-interop.ts
@@ -1,0 +1,29 @@
+import "./wrap-native";
+
+export function render(
+  jsx: Function,
+  type: any,
+  props: Record<string | number, unknown>,
+  key: string
+) {
+  if (typeof type.cssInterop === "function") {
+    return jsx(type, type.cssInterop(props), key);
+  } else {
+    return jsx(type, props, key);
+  }
+}
+
+export function defaultCSSInterop(props: Record<string, unknown>) {
+  if (typeof props.className === "string") {
+    const classNameStyle = { $$css: true, [props.className]: props.className };
+    props.style = Array.isArray(props.style)
+      ? [classNameStyle, ...props.style]
+      : props.style
+      ? [classNameStyle, props.style]
+      : classNameStyle;
+
+    delete props.className;
+  }
+
+  return props;
+}

--- a/packages/expo-router/src/css-interop/jsx-dev-runtime.ts
+++ b/packages/expo-router/src/css-interop/jsx-dev-runtime.ts
@@ -1,0 +1,14 @@
+import React from "react";
+import ReactJSXRuntime from "react/jsx-dev-runtime";
+
+import { render } from "./css-interop";
+
+export const Fragment = React.Fragment;
+
+export function jsx(type: any, props: any, key: any) {
+  return render((ReactJSXRuntime as any).jsx, type, props, key);
+}
+
+export function jsxs(type: any, props: any, key: any) {
+  return render((ReactJSXRuntime as any).jsxs, type, props, key);
+}

--- a/packages/expo-router/src/css-interop/jsx-runtime.ts
+++ b/packages/expo-router/src/css-interop/jsx-runtime.ts
@@ -1,0 +1,14 @@
+import React from "react";
+import ReactJSXRuntime from "react/jsx-runtime";
+
+import { render } from "./css-interop";
+
+export const Fragment = React.Fragment;
+
+export function jsx(type: any, props: any, key: any) {
+  return render((ReactJSXRuntime as any).jsx, type, props, key);
+}
+
+export function jsxs(type: any, props: any, key: any) {
+  return render((ReactJSXRuntime as any).jsxs, type, props, key);
+}

--- a/packages/expo-router/src/css-interop/wrap-native.ts
+++ b/packages/expo-router/src/css-interop/wrap-native.ts
@@ -1,0 +1,9 @@
+import { Image, ImageBackground, Pressable, Text, View } from "react-native";
+
+import { defaultCSSInterop } from "./css-interop";
+
+Object.assign(Image, { cssInterop: defaultCSSInterop });
+Object.assign(ImageBackground, { cssInterop: defaultCSSInterop });
+Object.assign(Pressable, { cssInterop: defaultCSSInterop });
+Object.assign(Text, { cssInterop: defaultCSSInterop });
+Object.assign(View, { cssInterop: defaultCSSInterop });

--- a/packages/expo-router/src/index.tsx
+++ b/packages/expo-router/src/index.tsx
@@ -1,3 +1,8 @@
+import React from "react";
+
 export { Stack } from "./layouts/Stack";
 export { Tabs } from "./layouts/Tabs";
 export * from "./exports";
+
+export const createElement = React.createElement;
+export const fragment = React.Fragment;


### PR DESCRIPTION
# Motivation

Experimental support for a new `jsxImportSource` to provide better css interoperability.

This is not a complete feature, rather a prototype that we can discuss on. This prototype allows for `className` to be set on `Text`/`View`/`Image` components.

# Execution

Update `babel.config.js` 

```
    presets: [
      [
        "babel-preset-expo",
        { useTransformReactJSXExperimental: true, jsxImportSource: "expo-router" },
      ],
    ],
```

You can now style components using `className`

```
<View className="text-red-500" />
// is the same as 
<View style={{ $$css: true, "text-red-500": "text-red-500" }} />
```