### PR TITLE
Update typescript.md

### DIFF
--- a/docs/docs/lab/typescript.md
+++ b/docs/docs/lab/typescript.md
@@ -7,7 +7,7 @@ title: TypeScript
 Expo Router provides an integrated TypeScript experience. To get started:
 
 - Install TypeScript either by `yarn -D typescript` or `npm i -D typescript`
-- Run `npx tsc init` or `yarn tsc init` to initialise TypeScript
+- Run `npx tsc --init` or `yarn tsc --init` to initialise TypeScript
 - Set the environment variable `EXPO_USE_TYPED_ROUTER=true`
 
 When enabled, Expo Router will automatically adjust your environment to ensure Expo Router types are picked up by the TypeScript compiler.


### PR DESCRIPTION
Correcting typescript initialize script

# Motivation
Previously using either `yarn tsc init` or `npx tsc init` was giving an error 

<img width="1206" alt="Screenshot 1444-10-03 at 2 19 02 PM" src="https://user-images.githubusercontent.com/43112535/233836903-0321a920-9363-452b-9e3a-ecc3f2214605.png">

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# Execution
Just adding the double hyphens to the script 
<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
I ran the new script locally 

<img width="1207" alt="Screenshot 1444-10-03 at 2 19 17 PM" src="https://user-images.githubusercontent.com/43112535/233836929-d968f5f3-b576-443d-8589-f873e5bcc48d.png">

