### PR TITLE
fix: show tutorial on empty project

### DIFF
--- a/packages/expo-router/src/ExpoRoot.tsx
+++ b/packages/expo-router/src/ExpoRoot.tsx
@@ -45,19 +45,17 @@ export function ExpoRoot({ context }: { context: RequireContext }) {
 }
 
 function ContextNavigator({ context }: { context: RequireContext }) {
-  const {
-    shouldShowTutorial,
-    shouldShowSplash,
-    linking,
-    navigationRef,
-    onReady,
-    routeNode,
-  } = useNavigationStore(context);
+  const { shouldShowSplash, linking, navigationRef, onReady, routeNode } =
+    useNavigationStore(context);
 
-  if (shouldShowTutorial) {
-    const Tutorial = require("./onboard/Tutorial").Tutorial;
-    SplashScreen.hideAsync();
-    return <Tutorial />;
+  if (!routeNode) {
+    if (process.env.NODE_ENV === "production") {
+      throw new Error("No route found for initial URL");
+    } else {
+      const Tutorial = require("./onboard/Tutorial").Tutorial;
+      SplashScreen.hideAsync();
+      return <Tutorial />;
+    }
   }
 
   const Component = getQualifiedRouteComponent(routeNode);

--- a/packages/expo-router/src/__tests__/tutorial.test.tsx
+++ b/packages/expo-router/src/__tests__/tutorial.test.tsx
@@ -1,0 +1,9 @@
+import { renderRouter, screen } from "../testing-library";
+
+it("displays the tutorial when no routes exists", async () => {
+  renderRouter({});
+
+  expect(
+    await screen.findByText("Start by creating a file in the app directory.")
+  ).toBeDefined();
+});

--- a/packages/expo-router/src/getLinkingConfig.ts
+++ b/packages/expo-router/src/getLinkingConfig.ts
@@ -9,14 +9,16 @@ import {
   getStateFromPath,
 } from "./link/linking";
 
-export function getNavigationConfig(routes: RouteNode): {
+export function getNavigationConfig(routes: RouteNode | null): {
   initialRouteName?: string;
   screens: Record<string, Screen>;
 } {
   return getReactNavigationConfig(routes, true);
 }
 
-export function getLinkingConfig(routes: RouteNode): LinkingOptions<object> {
+export function getLinkingConfig(
+  routes: RouteNode | null
+): LinkingOptions<object> {
   return {
     prefixes: [],
     // @ts-expect-error

--- a/packages/expo-router/src/getReactNavigationConfig.ts
+++ b/packages/expo-router/src/getReactNavigationConfig.ts
@@ -90,12 +90,18 @@ export function getReactNavigationScreensConfig(
 }
 
 export function getReactNavigationConfig(
-  routes: RouteNode,
+  routes: RouteNode | null,
   metaOnly: boolean
 ): {
   initialRouteName?: string;
   screens: Record<string, Screen>;
 } {
+  if (!routes) {
+    return {
+      screens: {},
+    };
+  }
+
   return {
     initialRouteName: routes.initialRouteName,
     screens: getReactNavigationScreensConfig(routes.children, metaOnly),

--- a/packages/expo-router/src/navigationStore/index.ts
+++ b/packages/expo-router/src/navigationStore/index.ts
@@ -40,14 +40,13 @@ export class NavigationStore {
   ssrLocation: URL | undefined;
 
   navigationRef = navigationRef;
-  routeNode!: RouteNode;
+  routeNode!: RouteNode | null;
   linking!: LinkingOptions<object>;
   rootState: NavigationState | PartialState<NavigationState> | undefined;
   initialRootState: ResultState | undefined;
   url!: URL;
   routeInfo!: UrlObject;
 
-  shouldShowTutorial = false;
   _onReady?: () => void;
 
   constructor(ssrLocation?: URL) {
@@ -56,24 +55,12 @@ export class NavigationStore {
 
   initialise = (context: RequireContext, onReady: () => void) => {
     this._onReady = onReady;
-    this.routeNode = getRoutes(context)!;
+    this.routeNode = getRoutes(context);
 
     this.linking = getLinkingConfig(this.routeNode);
     this.initialRootState = getInitialState(this.linking, this.ssrLocation);
 
     this.handleRouteInfoChange(this.initialRootState);
-
-    if (process.env.NODE_ENV === "development") {
-      if (process.env.EXPO_ROUTER_IMPORT_MODE === "sync") {
-        this.shouldShowTutorial = !context.keys().some((key) => {
-          // NOTE(EvanBacon): This should only ever occur in development as it breaks lazily loading.
-          const component = context(key)?.default;
-          return typeof component === "function";
-        });
-      } else {
-        this.shouldShowTutorial = context.keys().length === 0;
-      }
-    }
   };
 
   handleRouteInfoChange = (

--- a/packages/expo-router/src/views/Sitemap.tsx
+++ b/packages/expo-router/src/views/Sitemap.tsx
@@ -17,7 +17,8 @@ import { NavigationStoreContext } from "../navigationStore";
 
 const INDENT = 24;
 
-function sortRouteNodeRoutes(routeNode: RouteNode) {
+function sortRouteNodeRoutes(routeNode: RouteNode | null) {
+  if (!routeNode) return [];
   return routeNode.children.filter((route) => !route.internal).sort(sortRoutes);
 }
 


### PR DESCRIPTION
# Motivation

@EvanBacon Please double check my logic here, but I believe checking for the tutorial isn't needed, as `getRoutes` will return `null` is there is no valid routing configuration.