### PR TITLE
fix(web): inifinite rerenders due to default prop value

### DIFF
--- a/packages/expo-router/src/ExpoRoot.tsx
+++ b/packages/expo-router/src/ExpoRoot.tsx
@@ -63,11 +63,14 @@ export function ExpoRoot({ context, location }: ExpoRootProps) {
   );
 }
 
+const initialUrl =
+  Platform.OS === "web" && typeof window !== "undefined"
+    ? new URL(window.location.href)
+    : undefined;
+
 function ContextNavigator({
   context,
-  location: initialLocation = Platform.OS === "web"
-    ? new URL(window.location.href)
-    : undefined,
+  location: initialLocation = initialUrl,
 }: ExpoRootProps) {
   const navigationRef = useNavigationContainerRef();
   const [shouldShowSplash, setShowSplash] = React.useState(


### PR DESCRIPTION
# Motivation

https://github.com/expo/router/pull/527 Caused an infinite re-render bug on web due to a new default URL being generated every render.

I need to add an e2e web smoke test :thinking: 