### PR TITLE
fix(head): ensure handoff works when moving between two native devices

### DIFF
--- a/docs/docs/features/head.md
+++ b/docs/docs/features/head.md
@@ -12,7 +12,27 @@ Native support can be found in the [handoff guide](/docs/lab/handoff).
 
 ## Usage
 
-The `<Head />` component can be imported in any route in the `app` directory, simply import using `expo-router/head`:
+Be sure to use the `expo-router` Config Plugin if you're planning to use on iOS:
+
+```json title=app.json
+{
+  "expo": {
+    "plugins": [
+      [
+        "expo-router",
+        {
+          // Set this to the URL where your iOS universal links can be accessed.
+          // For example, if I build an app "Bacon Blog" and host at `evanbacon.dev`
+          // then `origin` should be `https://evanbacon.dev`.
+          "origin": "<PRODUCTION_URL>"
+        }
+      ]
+    ]
+  }
+}
+```
+
+The `<Head />` component can be imported in any route in the `app` directory, import using `expo-router/head`:
 
 ```tsx title=app/index.js
 import { Text } from "react-native";

--- a/packages/expo-head/ios/ExpoHeadModule.swift
+++ b/packages/expo-head/ios/ExpoHeadModule.swift
@@ -130,6 +130,7 @@ public class ExpoHeadModule: Module {
         }
         
         // TODO: https://gist.github.com/alexruperez/ea81aa3e371f7d0d7ea5e594d7e9ad08
+        activity.targetContentIdentifier = value.id
         activity.persistentIdentifier = value.id
         activity.isEligibleForHandoff = value.isEligibleForHandoff
         activity.isEligibleForPrediction = value.isEligibleForPrediction;

--- a/packages/expo-head/src/ExpoHead.ios.tsx
+++ b/packages/expo-head/src/ExpoHead.ios.tsx
@@ -1,10 +1,10 @@
 import { useIsFocused } from "@react-navigation/core";
-// @ts-ignore: TODO -- extract these into a shared library to prevent cyclic dependencies
 import {
   useLocalSearchParams,
   useUnstableGlobalHref,
   usePathname,
   useSegments,
+  // @ts-ignore: TODO -- extract these into a shared library to prevent cyclic dependencies
 } from "expo-router";
 import React from "react";
 

--- a/packages/expo-head/src/ExpoHead.ios.tsx
+++ b/packages/expo-head/src/ExpoHead.ios.tsx
@@ -1,6 +1,10 @@
 import { useIsFocused } from "@react-navigation/core";
 // @ts-ignore: TODO -- extract these into a shared library to prevent cyclic dependencies
-import { useLocalSearchParams, usePathname, useSegments } from "expo-router";
+import {
+  useLocalSearchParams,
+  useUnstableGlobalHref,
+  useSegments,
+} from "expo-router";
 import React from "react";
 
 import { ExpoHead, UserActivity } from "./ExpoHeadModule";
@@ -19,13 +23,9 @@ function getLastSegment(path: string) {
 // TODO: Use Head Provider to collect all props so only one Head is rendered for a given route.
 
 function useAddressableLink() {
-  const pathname = usePathname();
+  const pathname = useUnstableGlobalHref();
   const params = useLocalSearchParams<any>();
-  const qs = new URLSearchParams(params).toString();
   let url = getStaticUrlFromExpoRouter(pathname);
-  if (qs) {
-    url += "?" + qs;
-  }
   return { url, pathname, params };
 }
 
@@ -181,7 +181,8 @@ function useActivityFromMetaChildren(meta: MetaNode[]) {
     webpageURL: url,
     activityType: ExpoHead!.activities.INDEXED_ROUTE,
     userInfo: {
-      href: pathname,
+      // TODO: This may need to be  versioned in the future, e.g. `_v1` if we change the format.
+      href,
     },
   };
 

--- a/packages/expo-router/plugin/src/index.ts
+++ b/packages/expo-router/plugin/src/index.ts
@@ -1,7 +1,23 @@
-import { ConfigPlugin } from "expo/config-plugins";
+import { ConfigPlugin, withInfoPlist } from "expo/config-plugins";
 import { validate } from "schema-utils";
 
 const schema = require("../options.json");
+
+const withExpoHeadIos: ConfigPlugin = (config) => {
+  return withInfoPlist(config, (config) => {
+    // $(PRODUCT_BUNDLE_IDENTIFIER).expo.index_route
+    if (!Array.isArray(config.modResults.NSUserActivityTypes)) {
+      config.modResults.NSUserActivityTypes = [];
+    }
+    // This ensures that stored `NSUserActivityType`s can be opened in-app.
+    // This is important for moving between native devices or from opening a link that was saved
+    // in a Quick Note or Siri Reminder.
+    config.modResults.NSUserActivityTypes.push(
+      "$(PRODUCT_BUNDLE_IDENTIFIER).expo.index_route"
+    );
+    return config;
+  });
+};
 
 const withRouter: ConfigPlugin<{
   /** Production origin URL where assets in the public folder are hosted. The fetch function is polyfilled to support relative requests from this origin in production, development origin is inferred using the Expo CLI development server. */
@@ -14,6 +30,8 @@ const withRouter: ConfigPlugin<{
   asyncRoutes?: string;
 }> = (config, props) => {
   validate(schema, props);
+
+  withExpoHeadIos(config);
 
   return {
     ...config,

--- a/packages/expo-router/src/ExpoRoot.tsx
+++ b/packages/expo-router/src/ExpoRoot.tsx
@@ -126,6 +126,7 @@ function ContextNavigator({
     } else {
       return {
         routeInfo: {
+          unstable_globalHref: "",
           pathname: "",
           params: {},
           segments: [],

--- a/packages/expo-router/src/LocationProvider.tsx
+++ b/packages/expo-router/src/LocationProvider.tsx
@@ -3,6 +3,7 @@ import { State } from "./fork/getPathFromState";
 type SearchParams = Record<string, string | string[]>;
 
 export type UrlObject = {
+  unstable_globalHref: string;
   pathname: string;
   readonly params: SearchParams;
   segments: string[];
@@ -18,6 +19,8 @@ export function getRouteInfoFromState(
   const { path } = getPathFromState(state, false);
   const qualified = getPathFromState(state, true);
   return {
+    // TODO: This may have a predefined origin attached in the future.
+    unstable_globalHref: path,
     pathname: path.split("?")["0"],
     ...getNormalizedStatePath(qualified),
   };
@@ -30,7 +33,7 @@ export function getNormalizedStatePath({
 }: {
   path: string;
   params: any;
-}): Omit<UrlObject, "pathname"> {
+}): Pick<UrlObject, "segments" | "params"> {
   const [pathname] = statePath.split("?");
   return {
     // Strip empty path at the start

--- a/packages/expo-router/src/exports.ts
+++ b/packages/expo-router/src/exports.ts
@@ -3,6 +3,7 @@ import { Navigator, Slot } from "./views/Navigator";
 
 export { useRouter } from "./link/useRouter";
 export {
+  useUnstableGlobalHref,
   usePathname,
   useLocalSearchParams,
   useSearchParams,

--- a/packages/expo-router/src/hooks.ts
+++ b/packages/expo-router/src/hooks.ts
@@ -59,6 +59,14 @@ export function useLinkingContext() {
   return useExpoRouterContext().linking;
 }
 
+/**
+ * @private
+ * @returns the current global pathname with query params attached. This may change in the future to include the hostname from a predefined universal link, i.e. `/foobar?hey=world` becomes `https://acme.dev/foobar?hey=world`
+ */
+export function useUnstableGlobalHref(): string {
+  return useRouteInfo().unstable_globalHref;
+}
+
 export function useSegments() {
   return useRouteInfo().segments;
 }


### PR DESCRIPTION
# Motivation

- need Info.plist modifications in order to make handoff work
- need to expose a global URL method which handles the special syntax, e.g. `/[profile]?profile=evan` -> `/evan` and not `/evan?profile=evan`
