### PR TITLE
Update requirement expo version on intro.md

### DIFF
--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -31,7 +31,7 @@ npx create-expo-app@latest --example with-router
 
 ## Getting Started
 
-> Expo Router supports `expo@46.0.13` and greater.
+> Expo Router supports `expo@48.0.0` and greater.
 
 Ensure your computer is [setup for running an Expo app](https://docs.expo.dev/get-started/installation/).
 


### PR DESCRIPTION
# Motivation

@marklawlor

Since 1.1.0, expo-router has required expo@48.0.0 but doc is not updated yet.

- close https://github.com/expo/router/issues/503#issuecomment-1539748674

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->
