### PR TITLE
fix: SplashScreen timing regression

### DIFF
--- a/packages/expo-router/src/ExpoRoot.tsx
+++ b/packages/expo-router/src/ExpoRoot.tsx
@@ -117,6 +117,7 @@ function ContextNavigator({
 
   const { routeNode, initialState, linking, getRouteInfo } = expoContext;
 
+  const [isReady, setIsReady] = React.useState(false);
   const [rootState, setRootState] = React.useState<RootStateContextType>(() => {
     if (initialState) {
       return {
@@ -167,10 +168,13 @@ function ContextNavigator({
           ref={navigationRef}
           initialState={initialState}
           linking={linking}
-          onReady={() => requestAnimationFrame(() => setShowSplash(false))}
+          onReady={() => {
+            setIsReady(true);
+            requestAnimationFrame(() => setShowSplash(false));
+          }}
         >
           <RootStateContext.Provider value={rootState}>
-            {!shouldShowSplash && <Component />}
+            {isReady && <Component />}
           </RootStateContext.Provider>
         </UpstreamNavigationContainer>
       </ExpoRouterContext.Provider>


### PR DESCRIPTION
# Motivation

https://github.com/expo/router/pull/527 incorrectly tied the rendering of the app to the removal of the `<SplashScreen />`. This is incorrect as we actually want to render the application once before removing the `<SplashScreen />`


# Execution

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
