### PR TITLE
feat(docs): reveal experimental features for v2

### DIFF
--- a/docs/docs/features/head.md
+++ b/docs/docs/features/head.md
@@ -1,7 +1,5 @@
 ---
 title: Head
-# TODO
-sidebar_class_name: hidden
 ---
 
 > This guide refers to upcoming Expo Router features, all of which are experimental.

--- a/docs/docs/lab/bundle-splitting.md
+++ b/docs/docs/lab/bundle-splitting.md
@@ -1,12 +1,10 @@
 ---
-title: Bundle Splitting
-# TODO
-sidebar_class_name: hidden
+title: Async Routes
 ---
 
-> This guide refers to upcoming Expo Router features, all of which are experimental. You may need to [use Expo CLI on `main`](https://github.com/expo/expo/tree/main/packages/%40expo/cli#contributing) to use these features.
+> This guide requires `expo@49.0.0-alpha.3` or greater––everything listed here is still experimental. You may need to [use Expo CLI on `main`](https://github.com/expo/expo/tree/main/packages/%40expo/cli#contributing) to use these features.
 
-Unlike standard projects, Expo Router can automatically split your JavaScript bundle based on the route files, using [React Suspense](https://react.dev/reference/react/Suspense). This enables faster development as only the routes you navigate to will be bundled/loaded into memory. This can also be useful for reducing the initial bundle size for your application.
+Expo Router can automatically split your JavaScript bundle based on the route files, using [React Suspense](https://react.dev/reference/react/Suspense). This enables faster development as only the routes you navigate to will be bundled/loaded into memory. This can also be useful for reducing the initial bundle size for your application.
 
 ## Setup
 
@@ -35,11 +33,16 @@ Next, enable the feature:
 ```json title=app.json
 {
   "expo": {
-    "extra": {
-      "router": {
-        "asyncRoutes": "development"
-      }
-    }
+    "plugins": [
+      [
+        "expo-router",
+        {
+          "origin": "https://acme.com",
+          // highlight-next-line
+          "asyncRoutes": "development"
+        }
+      ]
+    ]
   }
 }
 ```

--- a/docs/docs/lab/handoff.md
+++ b/docs/docs/lab/handoff.md
@@ -2,7 +2,7 @@
 title: Handoff
 ---
 
-> This guide refers to upcoming Expo Router features, all of which are experimental.
+> This guide requires `expo@49.0.0-alpha.3` or greater––everything listed here is still experimental. You may need to [use Expo CLI on `main`](https://github.com/expo/expo/tree/main/packages/%40expo/cli#contributing) to use these features.
 
 Handoff is a feature that enables users to continue browsing your app or website on another device. This functionality is generally very useful for users, but it can be difficult to implement. Expo Router streamlines a lot of the complexity of handoff by providing a simple API.
 
@@ -221,8 +221,9 @@ Ensure you can access the Ngrok URL (via the browser for example), before buildi
 
 Handoff between your Mac and iPhone/iPad is not supported in the Expo Go app. You must build and install your app on your device.
 
-**If you see the Safari icon in the App Switcher on your iPhone**, then it means handoff is not working. 
-- Ensure you are not using the `?mode=developer` suffix when testing handoff to native. 
+**If you see the Safari icon in the App Switcher on your iPhone**, then it means handoff is not working.
+
+- Ensure you are not using the `?mode=developer` suffix when testing handoff to native.
 - Also be sure you're not using the local development server URL, e.g. `http://localhost:8081` as this cannot be used as a valid app site association link, open the running Ngrok URL in your browser to test.
 - We've observed that in iOS 16.3.1 and macOS 13.0 (Ventura), bundle identifiers starting with `app.` and `io.` will _sometimes_ not trigger the native app to show up in the iOS task switcher. Use `com.` as the first part of your bundle identifier.
 

--- a/docs/docs/lab/root-html.md
+++ b/docs/docs/lab/root-html.md
@@ -1,10 +1,8 @@
 ---
-title: Custom Root HTML
-# TODO
-sidebar_class_name: hidden
+title: Root HTML
 ---
 
-> This guide refers to upcoming Expo Router features, all of which are experimental. You may need to [use Expo CLI on `main`](https://github.com/expo/expo/tree/main/packages/%40expo/cli#contributing) to use these features.
+> This guide requires `expo@49.0.0-alpha.3` or greater––everything listed here is still experimental. You may need to [use Expo CLI on `main`](https://github.com/expo/expo/tree/main/packages/%40expo/cli#contributing) to use these features.
 
 When you statically render an Expo website (`EXPO_USE_STATIC=1 yarn expo start` cite needed), the root HTML element for each page can be customized by creating an `apps/+html.js` file that exports a default HTML component.
 

--- a/docs/docs/lab/styles.md
+++ b/docs/docs/lab/styles.md
@@ -10,7 +10,7 @@ The preferred way to style your application is to use the `StyleSheet` API. This
 
 ## Global Styles
 
-> First available in `expo-router@1.2.2`.
+> This guide requires `expo@49.0.0-alpha.3` or greater––everything listed here is still experimental.
 
 > Warning: Global styles are web-only, usage will cause your application to diverge visually on native.
 
@@ -46,39 +46,13 @@ import "emoji-mart/css/emoji-mart.css";
 
 To enable CSS support, add the following changes to your Metro configuration:
 
-- Add `css` to the list of source extensions.
-- Use the Expo Babel transformer.
-
 ```js title=metro.config.js
 // Learn more https://docs.expo.io/guides/customizing-metro
 const { getDefaultConfig } = require("expo/metro-config");
 
-const config = getDefaultConfig(__dirname);
-
-config.transformer = {
-  ...config.transformer,
-  // Use the Expo transformer.
-  babelTransformerPath: require.resolve("@expo/metro-runtime/transformer"),
-};
-
-// Ensure CSS is treated as a source file.
-config.resolver.sourceExts.push("css");
+const config = getDefaultConfig(__dirname, {
+  isCSSEnabled: true,
+});
 
 module.exports = config;
-```
-
-### Advanced Setup
-
-If you need to apply other transformations to your source before using the CSS transformer, you can create a custom Metro transformer.
-
-```js title=transformer.js
-const ExpoTransformer = require("@expo/metro-runtime/transformer");
-
-module.exports.transform = async (props) => {
-  // Mutate the `props` as needed before passing it to the Expo transformer.
-
-  // The Expo transformer will apply any changes then run through the default
-  // Metro transformer.
-  return ExpoTransformer.transform(props);
-};
 ```

--- a/docs/docs/lab/typescript.md
+++ b/docs/docs/lab/typescript.md
@@ -1,10 +1,8 @@
 ---
 title: TypeScript
-# TODO
-sidebar_class_name: hidden
 ---
 
-> This guide refers to upcoming Expo Router features, all of which are experimental.
+> This guide requires `expo@49.0.0-alpha.3` or greater––everything listed here is still experimental.
 
 Expo Router provides an integrated TypeScript experience. To get started:
 


### PR DESCRIPTION
# Motivation

Features can now be used with Expo SDK 49 alpha, so it's safe to show in the docs.
