### PR TITLE
chore(docs): document additional metro overrides

### DIFF
--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -85,7 +85,9 @@ If you use **Yarn**:
 {
   "resolutions": {
     "metro": "0.76.0",
-    "metro-resolver": "0.76.0"
+    "metro-resolver": "0.76.0",
+    "metro-config": "0.76.0",
+    "metro-transform-worker": "0.76.0"
   }
 }
 ```

--- a/docs/docs/troubleshooting.md
+++ b/docs/docs/troubleshooting.md
@@ -39,3 +39,10 @@ registerRootComponent(App);
 - This can happen if you are using an `expo` version lower than `expo@^46.0.13`. The version `46.0.13` enables context modules and injects `process.env.EXPO_ROUTER_APP_ROOT` into the process.
 - This can also be the result of using a custom version of `@expo/metro-config` that does not enable context modules.
 - Expo Router requires the project `metro.config.js` file to use `expo-router/metro` as the default configuration. Delete the `metro.config.js` file, or extend `expo/metro-config`. [Learn more](https://docs.expo.dev/guides/customizing-metro/)
+
+## `main.jsbundle does not exist`, build errors involving metro
+
+- This generally means an error ended metro's bundling process early.
+- This can happen if `metro-` package versions are mismatched.
+- If using newer versions of `metro` than the specific version in the installation guide, you may need to override additional `metro-` packages to the version you're using.
+- See the `resolutions` in the [router package.json](https://github.com/expo/router/blob/main/package.json) for a complete list of `metro-` packages.


### PR DESCRIPTION
# Motivation
Recommendation from metro maintainer: https://github.com/facebook/metro/issues/979#issuecomment-1546705585

- Docs say to use `metro` and `metro-resolver` 0.76.0 or newer
- Many folks, like me, will try using a range to stay up to date
- As of 0.76.4, other metro packages being at different versions cause errors and build failures

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# Execution
- Add additional metro overrides to docs that are known to be required for 0.76.4:
  - `metro-config`
  - `metro-transform-worker`
- Add a troubleshooting note for folks that may run into metro package version sync issues

It's possible no one else will use a range and this is a very limited issue. It's also possible for 
