### PR TITLE
chore(docs): update wrong env var (`EXPO_USE_TYPED_ROUTER `) name in typed routes section of the docs

### DIFF
--- a/docs/docs/lab/typescript.md
+++ b/docs/docs/lab/typescript.md
@@ -8,11 +8,11 @@ Expo Router provides an integrated TypeScript experience. To get started:
 
 - Install TypeScript either by `yarn add -D typescript` or `npm i -D typescript`
 - Run `npx tsc --init` or `yarn tsc --init` to initialise TypeScript
-- Set the environment variable `EXPO_USE_TYPED_ROUTER=true`
+- Set the environment variable `EXPO_USE_TYPED_ROUTES=true`
 
 When enabled, Expo Router will automatically adjust your environment to ensure Expo Router types are picked up by the TypeScript compiler.
 
-> If `EXPO_USE_TYPED_ROUTER` is removed, Expo Router will remove the changes it made
+> If `EXPO_USE_TYPED_ROUTES` is removed, Expo Router will remove the changes it made
 
 ## Statically Typed Links
 


### PR DESCRIPTION
# Motivation

I wanted to try out the new typed routes feature lately. After going through the [Expo Router - Typescript | Typed Router](https://expo.github.io/router/docs/lab/typescript/), something was still not quite working. Turned out that it was because of an invalid env var name

# Execution

Using the correct env var name helped. That is `EXPO_USE_TYPED_ROUTES=true expo start`

# Test Plan

1. Start the bundler with: `EXPO_USE_TYPED_ROUTES=true expo start`
2. Expo should generate types for the router correctly
