### PR TITLE
Issue #370 fixed

### DIFF
--- a/packages/expo-router/src/link/useLinkToPath.ts
+++ b/packages/expo-router/src/link/useLinkToPath.ts
@@ -75,6 +75,11 @@ export function useLinkToPath() {
 
       const rootState = navigationRef.getRootState();
 
+      // If the root state is null, we can't do anything
+      if(!rootState) {
+        return;
+      }
+
       // Ensure simple operations are used when moving between siblings
       // in the same navigator. This ensures that the state is not reset.
       // TODO: We may need to apply this at a larger scale in the future.


### PR DESCRIPTION
# Motivation

When I have set up an AuthProvider like specified here [Authentication - Expo Router](https://expo.github.io/router/docs/guides/auth/), it threw a TypeError when executing the `router.replace()` method. When I tracked it down, I concluded that in ***/packages/expo-router/src/link/useLinkToPath.ts*** on ***line 94***, the access to `knownOwnerState.type` was causing the issue. The `knownOwnerState` object was undefined in the first renders. Tracking further I found that `knownOwnerState` is the result of the ***line 88*** of the file and it is derived from `rootState` which is defined on ***line 76*** and obviously was undefined in the first renders.

In ***/packages/expo-router/src/link/useLinkToPath.ts***
- `router.replace('/sign-in')`
- line 76 ` rootState` -> **undefined**.
- line 88 `knownOwnerState` -> **undefined**.
- line 94 `knownOwnerState.type` ==> **TypeError**.

# Execution

I have added in ***/packages/expo-router/src/link/useLinkToPath.ts*** on ***line 79***:
```
if(!rootState) {
  return;
}
```
this step has fixed the problem.