### PR TITLE
Add missing required dependency in getting started guide

### DIFF
--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -44,7 +44,7 @@ npx create-expo-app
 Install `expo-router` and peer dependencies:
 
 ```bash
-npx expo install expo-router react-native-safe-area-context react-native-screens expo-linking expo-constants expo-status-bar
+npx expo install expo-router react-native-safe-area-context react-native-screens expo-linking expo-constants expo-status-bar react-native-gesture-handler
 ```
 
 Then delete the entry point in your `package.json`, or replace it with `index.js` to be explicit:


### PR DESCRIPTION
Update intro.md file: add react-native-gesture-handler

# Motivation
This issue will solve app crashing for beginners or new people who try `expo-router` ! I've put a description in a [related issue](https://github.com/expo/router/issues/593) for more information. 
