### PR TITLE
refactor: move the context stubs into a new file

### DIFF
--- a/packages/expo-router/src/testing-library/context-stubs.ts
+++ b/packages/expo-router/src/testing-library/context-stubs.ts
@@ -1,0 +1,47 @@
+import path from "path";
+
+import requireContext from "./require-context-ponyfill";
+
+export type ReactComponent = () => React.ReactElement<any, any> | null;
+export type FileStub = { default: ReactComponent } | ReactComponent;
+
+export { requireContext };
+
+export function inMemoryContext(context: Record<string, FileStub>) {
+  return Object.assign(
+    function (id: string) {
+      id = id.replace(/^\.\//, "").replace(/\.js$/, "");
+      return typeof context[id] === "function"
+        ? { default: context[id] }
+        : context[id];
+    },
+    {
+      keys: () => Object.keys(context).map((key) => "./" + key + ".js"),
+      resolve: (key: string) => key,
+      id: "0",
+    }
+  );
+}
+
+export function requireContextWithOverrides(
+  dir: string,
+  overrides: Record<string, FileStub>
+) {
+  const existingContext = requireContext(path.resolve(process.cwd(), dir));
+
+  return Object.assign(
+    function (id: string) {
+      if (id in overrides) {
+        const route = overrides[id];
+        return typeof route === "function" ? { default: route } : route;
+      } else {
+        return existingContext(id);
+      }
+    },
+    {
+      keys: () => [...Object.keys(overrides), ...existingContext.keys()],
+      resolve: (key: string) => key,
+      id: "0",
+    }
+  );
+}


### PR DESCRIPTION
# Motivation

The work on https://github.com/expo/router/issues/575 is touching to many files, so I'm breaking it up into smaller logical chunks.

This PR focuses on moving the context stubs from the testing-library utils into a separate function. I'll be reusing this logic to create unit tests for hooks and ensure the hook & imperative API's are working correctly together

For example, in an upcoming PR I'll be changing the[ `useSegments` test](https://github.com/expo/router/blob/91ac19c8685c0bdf13496ef7cea47aa1d5bdafe9/packages/expo-router/src/__tests__/hooks.test.node.tsx#L22-L27) not to override `React.useContext` but to work like this.

```tsx
function wrapperFn(context: Record<string, FileStub>, initialUrl = "/") {
  return function wrapper({ children }) {
     useExpoRouterStore(context, initialUrl)
     return children;
  };
}

describe(useSegments, () => {
  it(`defaults abstract types`, () => {
    const { result } = renderHook(() => useSegments(), {
      wrapper: wrapperFn({}),
    });
    const segments = result.current;
    expectType<string>(segments[0]);
    expectType<string[]>(segments);
  });
})
```