### PR TITLE
fix(router): show tutorial page

### DIFF
--- a/packages/expo-router/src/ExpoRoot.tsx
+++ b/packages/expo-router/src/ExpoRoot.tsx
@@ -23,9 +23,15 @@ function getGestureHandlerRootView() {
     const { GestureHandlerRootView } =
       require("react-native-gesture-handler") as typeof import("react-native-gesture-handler");
 
-    return function GestureHandler(props: any) {
+    // eslint-disable-next-line no-inner-declarations
+    function GestureHandler(props: any) {
       return <GestureHandlerRootView style={{ flex: 1 }} {...props} />;
-    };
+    }
+    if (process.env.NODE_ENV === "development") {
+      // @ts-expect-error
+      GestureHandler.displayName = "GestureHandlerRootView";
+    }
+    return GestureHandler;
   } catch {
     return React.Fragment;
   }

--- a/packages/expo-router/src/__tests__/useCreateExpoRouterContext.test.node.tsx
+++ b/packages/expo-router/src/__tests__/useCreateExpoRouterContext.test.node.tsx
@@ -5,7 +5,99 @@ import { RequireContext } from "../types";
 import {
   ExpoRootProps,
   useCreateExpoRouterContext,
+  createExpoRouterContext,
 } from "../useCreateExpoRouterContext";
+
+describe(createExpoRouterContext, () => {
+  it(`creates mock context with empty routes`, () => {
+    expect(
+      createExpoRouterContext({
+        context: createMockContextModule({}),
+      })
+    ).toEqual({
+      getRouteInfo: expect.any(Function),
+      initialState: undefined,
+      linking: {
+        prefixes: [],
+      },
+      routeNode: null,
+    });
+  });
+  it(`creates qualified context with routes`, () => {
+    const ctx = createExpoRouterContext({
+      context: createMockContextModule({
+        "./index.tsx": {
+          default: () => null,
+        },
+      }),
+    });
+
+    expect(ctx.linking).toEqual({
+      config: {
+        initialRouteName: undefined,
+        screens: { "[...404]": "*404", _sitemap: "_sitemap", index: "" },
+      },
+      getActionFromState: expect.any(Function),
+      getInitialURL: expect.any(Function),
+      getPathFromState: expect.any(Function),
+      getStateFromPath: expect.any(Function),
+      prefixes: [],
+      subscribe: expect.any(Function),
+    });
+
+    // Important
+    expect(ctx.initialState).toEqual(undefined);
+
+    expect(ctx.routeNode).toEqual({
+      children: [
+        {
+          children: [],
+          contextKey: "./index.tsx",
+          dynamic: null,
+          loadRoute: expect.any(Function),
+          route: "index",
+        },
+        {
+          children: [],
+          contextKey: "./_sitemap.tsx",
+          dynamic: null,
+          generated: true,
+          internal: true,
+          loadRoute: expect.any(Function),
+          route: "_sitemap",
+        },
+        {
+          children: [],
+          contextKey: "./[...404].tsx",
+          dynamic: [{ deep: true, name: "404" }],
+          generated: true,
+          internal: true,
+          loadRoute: expect.any(Function),
+          route: "[...404]",
+        },
+      ],
+      contextKey: "./_layout.tsx",
+      dynamic: null,
+      generated: true,
+      loadRoute: expect.any(Function),
+      route: "",
+    });
+  });
+  it(`creates qualified context with routes and initial state`, () => {
+    const ctx = createExpoRouterContext({
+      location: new URL("/", "http://acme.com"),
+      context: createMockContextModule({
+        "./index.tsx": {
+          default: () => null,
+        },
+      }),
+    });
+
+    expect(ctx.initialState).toEqual({
+      routes: [{ name: "index", path: "/" }],
+    });
+  });
+});
 
 function createMockContextModule(
   map: Record<string, Record<string, any>> = {}

--- a/packages/expo-router/src/__tests__/useCreateExpoRouterContext.test.node.tsx
+++ b/packages/expo-router/src/__tests__/useCreateExpoRouterContext.test.node.tsx
@@ -1,0 +1,79 @@
+import { render } from "@testing-library/react-native";
+import React from "react";
+
+import { RequireContext } from "../types";
+import {
+  ExpoRootProps,
+  useCreateExpoRouterContext,
+} from "../useCreateExpoRouterContext";
+
+function createMockContextModule(
+  map: Record<string, Record<string, any>> = {}
+) {
+  const contextModule = jest.fn((key) => map[key]);
+
+  Object.defineProperty(contextModule, "keys", {
+    value: () => Object.keys(map),
+  });
+
+  return contextModule as unknown as RequireContext;
+}
+
+function MockComponent(props: ExpoRootProps) {
+  useCreateExpoRouterContext(props);
+  return null;
+}
+
+describe(useCreateExpoRouterContext, () => {
+  beforeEach(() => {
+    // @ts-expect-error
+    jest.spyOn(Array.prototype, "reduce");
+  });
+  it(`computes on render`, () => {
+    render(
+      <MockComponent
+        context={createMockContextModule({})}
+        location={undefined}
+      />
+    );
+
+    expect(Array.prototype.reduce).toHaveBeenCalled();
+  });
+
+  it("does not re-compute the value when props are the same", () => {
+    const context = createMockContextModule({});
+    const location = new URL("/hello", "https://acme.com");
+    const { rerender } = render(
+      <MockComponent context={context} location={location} />
+    );
+
+    // @ts-expect-error
+    Array.prototype.reduce.mockClear();
+
+    rerender(<MockComponent context={context} location={location} />);
+
+    expect(Array.prototype.reduce).not.toHaveBeenCalled();
+  });
+
+  it("re-computes the value when context changes", () => {
+    const location = new URL("/hello", "https://acme.com");
+    const { rerender } = render(
+      <MockComponent
+        context={createMockContextModule({})}
+        location={location}
+      />
+    );
+
+    // @ts-expect-error
+    Array.prototype.reduce.mockClear();
+
+    rerender(
+      <MockComponent
+        context={createMockContextModule({ "hello.js": { default: null } })}
+        location={location}
+      />
+    );
+
+    expect(Array.prototype.reduce).toHaveBeenCalled();
+  });
+});

--- a/packages/expo-router/src/useCreateExpoRouterContext.ts
+++ b/packages/expo-router/src/useCreateExpoRouterContext.ts
@@ -1,0 +1,83 @@
+import React from "react";
+import { Platform } from "react-native";
+
+import { getRouteInfoFromState } from "./LocationProvider";
+import getPathFromState, {
+  getPathDataFromState,
+} from "./fork/getPathFromState";
+import { ResultState } from "./fork/getStateFromPath";
+import { getLinkingConfig } from "./getLinkingConfig";
+import { getRoutes } from "./getRoutes";
+import {
+  ExpoRouterContextType,
+  OnboardingExpoRouterContextType,
+} from "./hooks";
+import { RequireContext } from "./types";
+// import URL from "url-parse";
+
+export type ExpoRootProps = {
+  context: RequireContext;
+  location?: URL;
+};
+
+const initialUrl =
+  Platform.OS === "web" && typeof window !== "undefined"
+    ? new URL(window.location.href)
+    : undefined;
+
+export function useCreateExpoRouterContext({
+  context,
+  location = initialUrl,
+}: ExpoRootProps) {
+  return React.useMemo<
+    | Omit<ExpoRouterContextType, "navigationRef">
+    | Omit<OnboardingExpoRouterContextType, "navigationRef">
+  >(() => {
+    const routeNode = getRoutes(context);
+
+    // No app dir exists
+    if (!routeNode) {
+      return {
+        routeNode,
+        linking: { prefixes: [] },
+        initialState: undefined,
+        getRouteInfo() {
+          throw new Error("invalid");
+        },
+      };
+    }
+
+    const linking = getLinkingConfig(routeNode);
+    let initialState: ResultState | undefined;
+
+    if (location) {
+      initialState = linking.getStateFromPath?.(
+        location.pathname + location.search,
+        linking.config
+      );
+    }
+
+    function getRouteInfo(state: ResultState) {
+      return getRouteInfoFromState(
+        (state: Parameters<typeof getPathFromState>[0], asPath: boolean) => {
+          return getPathDataFromState(state, {
+            screens: [],
+            ...linking.config,
+            preserveDynamicRoutes: asPath,
+            preserveGroups: asPath,
+          });
+        },
+        state
+      );
+    }
+
+    // This looks redundant but it makes TypeScript correctly infer the union return type.
+    return {
+      routeNode,
+      linking,
+
+      initialState,
+      getRouteInfo,
+    };
+  }, [context, location]);
+}


### PR DESCRIPTION
# Motivation

- fix regression from #527 which prevented the tutorial page from being shown.

# Test Plan

- added more tests to ensure this functionality remains working.
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
