### PR TITLE
fix fast refresh

### DIFF
--- a/packages/expo-router/entry.js
+++ b/packages/expo-router/entry.js
@@ -1,6 +1,8 @@
+// `@expo/metro-runtime` MUST be the first import to ensure Fast Refresh works
+// on web.
+import "@expo/metro-runtime";
 import { ExpoRoot } from "expo-router";
 import Head from "expo-router/head";
-import "@expo/metro-runtime";
 import { renderRootComponent } from "expo-router/src/renderRootComponent";
 
 const ctx = require.context(


### PR DESCRIPTION
# Motivation

Fast Refresh must be setup before React Native is imported. This used to work but the feature regressed in #447

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# Execution

Ensure `@expo/metro-runtime` is the first import in `expo-router/entry`.

Alternatively, something like this could also ensure the feature keeps working:

```js 
// metro.config.js
config.serializer = {
  ...config.serializer,
  getModulesRunBeforeMainModule: () => [
    require.resolve("@expo/metro-runtime"),
    require.resolve("react-native/Libraries/Core/InitializeCore"),
  ],
};
```

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

Fast refresh will work on web.

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
