### PR TITLE
fix(router): encode query parameter values when resolving href

### DIFF
--- a/packages/expo-router/src/link/__tests__/href.test.node.ts
+++ b/packages/expo-router/src/link/__tests__/href.test.node.ts
@@ -54,4 +54,9 @@ describe(resolveHref, () => {
       })
     ).toBe("/alpha/some?gamma=another");
   });
+  it("encodes query parameters", () => {
+    expect(
+      resolveHref({ pathname: "/fake/path", params: { value: "++test++" } })
+    ).toBe("/fake/path?value=%2B%2Btest%2B%2B");
+  });
 });

--- a/packages/expo-router/src/link/href.ts
+++ b/packages/expo-router/src/link/href.ts
@@ -55,6 +55,6 @@ function encodeParam(param: any): string {
 
 function createQueryParams(params: Record<string, any>): string {
   return Object.entries(params)
-    .map(([key, value]) => `${key}=${encodeURIComponent(value)}`)
+    .map(([key, value]) => `${key}=${encodeURIComponent(value.toString())}`)
     .join("&");
 }

--- a/packages/expo-router/src/link/href.ts
+++ b/packages/expo-router/src/link/href.ts
@@ -55,6 +55,6 @@ function encodeParam(param: any): string {
 
 function createQueryParams(params: Record<string, any>): string {
   return Object.entries(params)
-    .map((props) => props.join("="))
+    .map(([key, value]) => `${key}=${encodeURIComponent(value)}`)
     .join("&");
 }


### PR DESCRIPTION
# Motivation

Fixes #577

# Execution

- We already encode the pathname keys, like `/user/[id]`
- Added `encodeURIComponent` when generating the query parameters for the same URL

# Test Plan

See added test, and repro in #577