### PR TITLE
prevent root rerender

### DIFF
--- a/packages/expo-router/src/ExpoRoot.tsx
+++ b/packages/expo-router/src/ExpoRoot.tsx
@@ -147,6 +147,15 @@ function ContextNavigator({
     return () => subscription?.();
   }, [navigationRef, getRouteInfo]);
 
+  const Component = routeNode ? getQualifiedRouteComponent(routeNode) : null;
+
+  const comp = React.useMemo(() => {
+    if (!Component) {
+      return null;
+    }
+    return <Component />;
+  }, [Component, shouldShowSplash]);
+
   if (!routeNode) {
     if (process.env.NODE_ENV === "development") {
       const Tutorial = require("./onboard/Tutorial").Tutorial;
@@ -156,8 +165,6 @@ function ContextNavigator({
       throw new Error("No routes found");
     }
   }
-
-  const Component = getQualifiedRouteComponent(routeNode);
 
   return (
     <>
@@ -170,7 +177,7 @@ function ContextNavigator({
           onReady={() => requestAnimationFrame(() => setShowSplash(false))}
         >
           <RootStateContext.Provider value={rootState}>
-            {!shouldShowSplash && <Component />}
+            {!shouldShowSplash && comp}
           </RootStateContext.Provider>
         </UpstreamNavigationContainer>
       </ExpoRouterContext.Provider>

--- a/packages/expo-router/src/__tests__/smoke.test.tsx
+++ b/packages/expo-router/src/__tests__/smoke.test.tsx
@@ -137,8 +137,8 @@ it("nested layouts", async () => {
 
   expect(AppLayout).toHaveBeenCalledTimes(3);
   expect(TabsLayout).toHaveBeenCalledTimes(2);
-  expect(StackLayout).toHaveBeenCalledTimes(3);
+  expect(StackLayout).toHaveBeenCalledTimes(2);
   expect(Index).toHaveBeenCalledTimes(1);
-  expect(Home).toHaveBeenCalledTimes(2);
+  expect(Home).toHaveBeenCalledTimes(1);
   expect(HomeNested).toHaveBeenCalledTimes(1);
 });


### PR DESCRIPTION
# Motivation

Prevent the root from rerendering when the state changes

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# Execution

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
