### PR TITLE
fix(router): Implement better splash imperative API

### DIFF
--- a/apps/sandbox/app.config.js
+++ b/apps/sandbox/app.config.js
@@ -20,6 +20,7 @@ module.exports = {
     bundler: "metro",
   },
   plugins: [
+    "expo-head",
     [
       "expo-router",
       {
@@ -43,5 +44,4 @@ module.exports = {
       CoreSpotlightContinuation: true,
     },
   },
-  plugins: ["expo-head"],
 };

--- a/packages/expo-head/src/ExpoHead.ios.tsx
+++ b/packages/expo-head/src/ExpoHead.ios.tsx
@@ -220,7 +220,7 @@ const activities: Map<string, UserActivity> = new Map();
 function useRegisterCurrentActivity(activity: UserActivity) {
   // ID is tied to Expo Router and agnostic of URLs to ensure dynamic parameters are not considered.
   // Using all segments ensures that cascading routes are considered.
-  const activityId = urlToId(usePathname());
+  const activityId = urlToId(usePathname() || "/");
   const cascadingId = urlToId(useSegments().join("-") || "-");
   const activityIds = Array.from(activities.keys());
   const cascadingActivity: UserActivity = React.useMemo(() => {
@@ -255,7 +255,6 @@ function useRegisterCurrentActivity(activity: UserActivity) {
     }
 
     previousActivity.current = cascadingActivity;
-
     if (!cascadingActivity.id) {
       throw new Error("Activity must have an ID");
     }

--- a/packages/expo-metro-runtime/src/error-overlay/LogBox.web.ts
+++ b/packages/expo-metro-runtime/src/error-overlay/LogBox.web.ts
@@ -31,10 +31,8 @@ interface ILogBox {
  */
 if (__DEV__) {
   const LogBoxData = require("./Data/LogBoxData");
-  const {
-    parseLogBoxLog,
-    parseInterpolation,
-  } = require("./Data/parseLogBoxLog");
+  const { parseLogBoxLog, parseInterpolation } =
+    require("./Data/parseLogBoxLog") as typeof import("./Data/parseLogBoxLog");
 
   let originalConsoleError: typeof console.error | undefined;
   let consoleErrorImpl: typeof console.error | undefined;
@@ -148,7 +146,11 @@ if (__DEV__) {
         originalConsoleError?.(interpolated.message.content);
 
         LogBoxData.addLog({
-          level: "error",
+          // Always show the static rendering issues as full screen since they
+          // are too confusing otherwise.
+          level: /did not match\. Server:/.test(message.content)
+            ? "fatal"
+            : "error",
           category,
           message,
           componentStack,

--- a/packages/expo-metro-runtime/src/error-overlay/LogBox.web.ts
+++ b/packages/expo-metro-runtime/src/error-overlay/LogBox.web.ts
@@ -139,13 +139,20 @@ if (__DEV__) {
         return;
       }
 
-      const { message } = parseLogBoxLog(args);
+      const { category, message, componentStack } = parseLogBoxLog(args);
 
       if (!LogBoxData.isMessageIgnored(message.content)) {
         // Interpolate the message so they are formatted for adb and other CLIs.
         // This is different than the message.content above because it includes component stacks.
         const interpolated = parseInterpolation(args);
         originalConsoleError?.(interpolated.message.content);
+
+        LogBoxData.addLog({
+          level: "error",
+          category,
+          message,
+          componentStack,
+        });
       }
     } catch (err) {
       LogBoxData.reportUnexpectedLogBoxError(err);

--- a/packages/expo-metro-runtime/src/location/install.native.ts
+++ b/packages/expo-metro-runtime/src/location/install.native.ts
@@ -1,3 +1,6 @@
+// This MUST be first to ensure that `fetch` is defined in the React Native environment.
+import "react-native/Libraries/Core/InitializeCore";
+
 import Constants from "expo-constants";
 import URL from "url-parse";
 

--- a/packages/expo-router/src/ExpoRoot.tsx
+++ b/packages/expo-router/src/ExpoRoot.tsx
@@ -1,7 +1,6 @@
 import { useNavigationContainerRef } from "@react-navigation/native";
 import { StatusBar } from "expo-status-bar";
 import React from "react";
-import { Platform } from "react-native";
 import { SafeAreaProvider } from "react-native-safe-area-context";
 
 import UpstreamNavigationContainer from "./fork/NavigationContainer";

--- a/packages/expo-router/src/ExpoRoot.tsx
+++ b/packages/expo-router/src/ExpoRoot.tsx
@@ -86,10 +86,13 @@ function ContextNavigator(props: ExpoRootProps) {
   React.useEffect(() => {
     const subscription = navigationRef.addListener("state", (data) => {
       const state = data.data.state as ResultState;
-      setRootState({
-        state,
-        routeInfo: getRouteInfo(state),
-      });
+      // This can sometimes be undefined when an error is thrown in the Root Layout Route.
+      if (state) {
+        setRootState({
+          state,
+          routeInfo: getRouteInfo(state),
+        });
+      }
     });
 
     return () => subscription?.();

--- a/packages/expo-router/src/renderRootComponent.tsx
+++ b/packages/expo-router/src/renderRootComponent.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { Platform, View } from "react-native";
 
 import registerRootComponent from "./fork/expo/registerRootComponent";
-import { SplashScreen } from "./views/Splash";
+import { SplashScreen, _internal_preventAutoHideAsync } from "./views/Splash";
 
 function isBaseObject(obj: any) {
   if (Object.prototype.toString.call(obj) !== "[object Object]") {
@@ -52,7 +52,11 @@ function convertError(error: any) {
  */
 export function renderRootComponent(Component: React.ComponentType<any>) {
   try {
-    SplashScreen.preventAutoHideAsync();
+    // This must be delayed so the user has a chance to call it first.
+    setTimeout(() => {
+      console.log("2. internal_preventAutoHideAsync");
+      _internal_preventAutoHideAsync();
+    });
 
     registerRootComponent(Component);
   } catch (e) {

--- a/packages/expo-router/src/views/Splash.tsx
+++ b/packages/expo-router/src/views/Splash.tsx
@@ -83,12 +83,10 @@ export const _internal_maybeHideAsync = () => {
   if (_userControlledAutoHideEnabled) {
     return;
   }
-  console.log("3. maybeHideAsync");
   SplashScreen.hideAsync();
 };
 
 SplashScreen.preventAutoHideAsync = () => {
-  console.log("1. userControlledAutoHideEnabled");
   _userControlledAutoHideEnabled = true;
   _internal_preventAutoHideAsync();
 };

--- a/packages/expo-router/src/views/Splash.tsx
+++ b/packages/expo-router/src/views/Splash.tsx
@@ -25,6 +25,11 @@ const globalStack: string[] = [];
  */
 export function SplashScreen() {
   useGlobalSplash();
+  React.useEffect(() => {
+    console.warn(
+      "The <SplashScreen /> component is deprecated. Use `SplashScreen.preventAutoHideAsync()` and `SplashScreen.hideAsync` from `expo-router` instead."
+    );
+  }, []);
   return null;
 }
 
@@ -48,9 +53,14 @@ SplashScreen.hideAsync = () => {
   globalStack.length = 0;
 };
 
+let _userControlledAutoHideEnabled = false;
 let _preventAutoHideAsyncInvoked = false;
 
-SplashScreen.preventAutoHideAsync = () => {
+// Expo Router uses this internal method to ensure that we can detect if the user
+// has explicitly opted into preventing the splash screen from hiding. This means
+// they will also explicitly hide it. If they don't, we will hide it for them after
+// the navigation render completes.
+export const _internal_preventAutoHideAsync = () => {
   // Memoize, this should only be called once.
   if (_preventAutoHideAsyncInvoked) {
     return;
@@ -65,6 +75,22 @@ SplashScreen.preventAutoHideAsync = () => {
     });
   }
   SplashModule.preventAutoHideAsync();
+};
+
+export const _internal_maybeHideAsync = () => {
+  // If the user has explicitly opted into preventing the splash screen from hiding,
+  // we should not hide it for them. This is often used for animated splash screens.
+  if (_userControlledAutoHideEnabled) {
+    return;
+  }
+  console.log("3. maybeHideAsync");
+  SplashScreen.hideAsync();
+};
+
+SplashScreen.preventAutoHideAsync = () => {
+  console.log("1. userControlledAutoHideEnabled");
+  _userControlledAutoHideEnabled = true;
+  _internal_preventAutoHideAsync();
 };
 
 SplashScreen._pushEntry = (): any => {


### PR DESCRIPTION
# Motivation

The declarative SplashScreen system doesn't work well when attempting to implement animated splash transitions.

If the components re-render then the splash screen will be hidden even if you are just updating state in an animated transition.

However, we still need a system for delaying the splash screen until the navigation has finished loading. To allow for both cases, we now have an internal API and external API for controlling the splash screen. If the user calls `SplashScreen.preventAutoHideAsync` from `expo-router` before the navigation finishes rendering, then the autohiding logic in `expo-router` will be disabled. If the user does nothing splash related, then `expo-router` will prevent auto-hiding until the navigation container has finished mounting.

Now if you want to implement some additional splash logic, simply do the following in `app/_layout.js`:

```js
import { Tabs, SplashScreen } from "expo-router";
import { useEffect } from "react";

export default function Layout() {
  SplashScreen.preventAutoHideAsync();
  useEffect(() => {
    setTimeout(() => {
      SplashScreen.hideAsync();
    }, 1500);
  }, []);
  ...
}
```

The `<SplashScreen />` component will now warn that the component-based API is deprecated.

# Test Plan

- Tested in both Expo Go and in a dev build.

