### PR TITLE
feat(router): Add SafeAreaView to the default navigator

### DIFF
--- a/packages/expo-router/e2e/__tests__/__snapshots__/export.test.ts.snap
+++ b/packages/expo-router/e2e/__tests__/__snapshots__/export.test.ts.snap
@@ -278,7 +278,7 @@ input::-webkit-search-cancel-button,input::-webkit-search-decoration,input::-web
 @keyframes r-9p3sdl{0%{transform:rotate(0deg);}100%{transform:rotate(360deg);}}
 @keyframes r-imtty0{0%{opacity:0;}100%{opacity:1;}}
 @keyframes r-ndfo3d{0%{transform:translateY(0%);}100%{transform:translateY(100%);}}
-@keyframes r-t2lo5v{0%{opacity:1;}100%{opacity:0;}}</style></head><body><div id="root"><div class="css-175oi2r" style="flex:1"><div class="css-175oi2r r-13awgt0"><div dir="auto" class="css-1rynq56">Index</div></div></div></div><script src="/bundles/[mock].js" defer></script></body></html>"
+@keyframes r-t2lo5v{0%{opacity:1;}100%{opacity:0;}}</style></head><body><div id="root"><div class="css-175oi2r" style="flex:1"><div class="css-175oi2r r-13awgt0"><div class="css-175oi2r" style="flex:1;padding-top:0px;padding-right:0px;padding-bottom:0px;padding-left:0px"><div dir="auto" class="css-1rynq56">Index</div></div></div></div></div><script src="/bundles/[mock].js" defer></script></body></html>"
 `;
 
 exports[`exports with nested static head 1`] = `

--- a/packages/expo-router/src/views/Navigator.tsx
+++ b/packages/expo-router/src/views/Navigator.tsx
@@ -4,6 +4,7 @@ import {
   useNavigationBuilder,
 } from "@react-navigation/native";
 import * as React from "react";
+import { SafeAreaView } from "react-native-safe-area-context";
 
 import { useContextKey } from "../Route";
 import { useFilterScreenChildren } from "../layouts/withLayoutContext";
@@ -148,9 +149,11 @@ export function QualifiedSlot() {
 
 export function DefaultNavigator() {
   return (
-    <Navigator>
-      <QualifiedSlot />
-    </Navigator>
+    <SafeAreaView style={{ flex: 1 }}>
+      <Navigator>
+        <QualifiedSlot />
+      </Navigator>
+    </SafeAreaView>
   );
 }
 


### PR DESCRIPTION
# Motivation

- An idea from @marklawlor to ensure the new user experience is as seamless as possible.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# Execution

- The default Layout Route (no `app/_layout.js`) will now have safe area padding. This can be removed by creating a `app/_layout.js` and exporting `<Slot />` or using any other navigator.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

## Before
<img width="565" alt="Screenshot 2023-06-02 at 1 03 36 AM" src="https://github.com/expo/router/assets/9664363/ac349fd5-8284-457a-a911-abbdcf8db97b">

## After

<img width="565" alt="Screenshot 2023-06-02 at 1 03 26 AM" src="https://github.com/expo/router/assets/9664363/8624cb83-7997-4552-bc8b-e7934b47402a">




<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
