### PR TITLE
feat(router): add support for the src directory to expo router

### DIFF
--- a/apps/sandbox/src/app/index.tsx
+++ b/apps/sandbox/src/app/index.tsx
@@ -1,0 +1,34 @@
+import { StyleSheet, Text, View } from "react-native";
+
+export default function Page() {
+  return (
+    <View style={styles.container}>
+      <View style={styles.main}>
+        <Text style={styles.title}>Hello World</Text>
+        <Text style={styles.subtitle}>This is the first page of your app.</Text>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: "center",
+    padding: 24,
+  },
+  main: {
+    flex: 1,
+    justifyContent: "center",
+    maxWidth: 960,
+    marginHorizontal: "auto",
+  },
+  title: {
+    fontSize: 64,
+    fontWeight: "bold",
+  },
+  subtitle: {
+    fontSize: 36,
+    color: "#38434D",
+  },
+});

--- a/packages/expo-router/babel.js
+++ b/packages/expo-router/babel.js
@@ -71,11 +71,7 @@ function getExpoRouterImportMode(projectRoot, platform) {
 }
 
 function directoryExistsSync(file) {
-  try {
-    return fs.statSync(file)?.isDirectory() ?? false;
-  } catch {
-    return false;
-  }
+  return fs.statSync(file, { throwIfNoEntry: false })?.isDirectory() ?? false;
 }
 
 function getRouterDirectory(projectRoot) {

--- a/packages/expo-router/src/onboard/Tutorial.tsx
+++ b/packages/expo-router/src/onboard/Tutorial.tsx
@@ -68,13 +68,24 @@ export function Tutorial() {
             style={styles.subtitle}
           >
             Start by creating a file{"\n"}in the{" "}
-            <Text style={{ fontWeight: "bold" }}>app</Text> directory.
+            <Text style={{ fontWeight: "bold" }}>{getRootDir()}</Text>{" "}
+            directory.
           </Text>
           {canAutoTouchFile && <Button />}
         </View>
       </SafeAreaView>
     </View>
   );
+}
+
+function getRootDir() {
+  const dir = process.env.EXPO_ROUTER_APP_ROOT!;
+  if (dir.match(/\/src\/app$/)) {
+    return "src/app";
+  } else if (dir.match(/\/app$/)) {
+    return "app";
+  }
+  return dir.split("/").pop() ?? dir;
 }
 
 function Button() {
@@ -85,6 +96,10 @@ function Button() {
       }}
       style={{
         ...Platform.select({
+          web: {
+            // subtle white shadow
+            boxShadow: "rgba(255, 255, 255, 0.15) 0px 0px 20px 5px",
+          },
           native: {
             position: "absolute",
             bottom: 24,
@@ -111,7 +126,8 @@ function Button() {
             selectable={false}
             style={[styles.code, hovered && { color: "black" }]}
           >
-            <Text style={{ color: "#BCC3CD" }}>$</Text> touch app/index.js
+            <Text style={{ color: "#BCC3CD" }}>$</Text> touch {getRootDir()}
+            /index.js
           </Text>
         </View>
       )}

--- a/packages/expo-router/src/onboard/createEntryFile.ts
+++ b/packages/expo-router/src/onboard/createEntryFile.ts
@@ -13,7 +13,15 @@ export function createEntryFileAsync() {
     method: "POST",
     body: JSON.stringify({
       contents: TEMPLATE,
+      // Legacy
       path: "./app/index.js",
+      // New
+      absolutePath:
+        process.env.EXPO_PROJECT_ROOT +
+        "/" +
+        process.env.EXPO_ROUTER_APP_ROOT +
+        "/" +
+        "./index.js",
     }),
   });
 }


### PR DESCRIPTION
# Motivation

- A lot of users want this, it seems reasonable.
- You can only change the directory from `app` to `src/app`. Arbitrary directory support is still not officially supported.
- This PR requires changes to Expo CLI as well, so the feature won't work until the latest CLI is published.
- The feature can be enabled by creating a `src/app` directory. Unlike other frameworks, Expo will default to the more specific directory name.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# Execution

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

- Tutorial shows `src/app` instead of `app`.
- Static rendering works as expected.
- Cache is invalidated when switching between the two and restarting.

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
