### PR TITLE
fix: 633 - update type of RequireContext id

### DIFF
--- a/packages/expo-router/src/types.ts
+++ b/packages/expo-router/src/types.ts
@@ -7,7 +7,7 @@ export interface RequireContext {
   /** **Unimplemented:** Return the module identifier for a user request. */
   resolve(id: string): string;
   /** **Unimplemented:** Readable identifier for the context module. */
-  id: string;
+  id: string | number;
 }
 
 /** The list of input keys will become optional, everything else will remain the same. */

--- a/packages/expo-router/types/metro-require.d.ts
+++ b/packages/expo-router/types/metro-require.d.ts
@@ -13,7 +13,7 @@ declare namespace __MetroModuleApi {
     /** **Unimplemented:** Return the module identifier for a user request. */
     resolve(id: string): string;
     /** **Unimplemented:** Readable identifier for the context module. */
-    id: string;
+    id: string | number;
   }
 
   interface RequireFunction {


### PR DESCRIPTION
# Motivation

Fixes: #633

# Execution

I've added a number union type for `RequireContext.id` in both places where it's referenced.

# Test Plan

Using this package with `@types/webpack-env` version 1.18.1 should not throw a type error (see issue).
