### PR TITLE
fix: do not reset isReady during fast-refresh

### DIFF
--- a/packages/expo-router/src/global-state/router-store.ts
+++ b/packages/expo-router/src/global-state/router-store.ts
@@ -51,7 +51,7 @@ export class RouterStore {
     initialLocation?: URL
   ) {
     // Clean up any previous state
-    this.isReady = Boolean(initialLocation);
+    this.isReady ||= Boolean(initialLocation);
     this.initialState = undefined;
     this.rootState = undefined;
     this.routeInfo = undefined;


### PR DESCRIPTION
# Motivation

In some fast refresh circumstances `isReady` could be reset to `false` causing a `navigation is not ready` error.