### PR TITLE
Fix react refresh for web with `output: single`

### DIFF
--- a/packages/expo-router/_app.tsx
+++ b/packages/expo-router/_app.tsx
@@ -1,0 +1,17 @@
+// The entry component (one that uses context modules) cannot be in the same file as the
+// entry side-effects, otherwise they'll be updated when files are added/removed from the
+// app directory. This will cause a lot of unfortunate errors regarding HMR and Fast Refresh.
+// This is because Fast Refresh is sending the entire file containing an updated component.
+import { ExpoRoot } from "expo-router";
+import Head from "expo-router/head";
+
+import { ctx } from "./_ctx";
+
+// Must be exported or Fast Refresh won't update the context
+export function App() {
+  return (
+    <Head.Provider>
+      <ExpoRoot context={ctx} />
+    </Head.Provider>
+  );
+}

--- a/packages/expo-router/entry.js
+++ b/packages/expo-router/entry.js
@@ -1,19 +1,11 @@
 // `@expo/metro-runtime` MUST be the first import to ensure Fast Refresh works
 // on web.
 import "@expo/metro-runtime";
-import { ExpoRoot } from "expo-router";
-import Head from "expo-router/head";
+
+// This file should only import and register the root. No components or exports
+// should be added here.
 import { renderRootComponent } from "expo-router/src/renderRootComponent";
 
-import { ctx } from "./_ctx";
-
-// Must be exported or Fast Refresh won't update the context
-export function App() {
-  return (
-    <Head.Provider>
-      <ExpoRoot context={ctx} />
-    </Head.Provider>
-  );
-}
+import { App } from "./_app";
 
 renderRootComponent(App);

--- a/packages/expo-router/package.json
+++ b/packages/expo-router/package.json
@@ -24,7 +24,8 @@
     "plugin",
     "app.plugin.js",
     "!**/__tests__",
-    "_ctx.*"
+    "_ctx.*",
+    "_app.tsx"
   ],
   "repository": {
     "url": "https://github.com/expo/router.git",

--- a/packages/expo-router/package.json
+++ b/packages/expo-router/package.json
@@ -104,7 +104,7 @@
   "dependencies": {
     "@bacons/react-views": "^1.1.3",
     "@expo/metro-runtime": "2.1.4",
-    "@radix-ui/react-slot": "^1.0.0",
+    "@radix-ui/react-slot": "1.0.1",
     "@react-navigation/bottom-tabs": "~6.5.7",
     "@react-navigation/native": "~6.1.6",
     "@react-navigation/native-stack": "~6.9.12",

--- a/packages/expo-router/src/fork/expo/registerRootComponent.tsx
+++ b/packages/expo-router/src/fork/expo/registerRootComponent.tsx
@@ -24,6 +24,9 @@ type InitialProps = {
   [key: string]: any;
 };
 
+// Web root tag is preserved for re-use between refreshes.
+let rootTag: import("react-dom/client").Root | null = null;
+
 export default function registerRootComponent<P extends InitialProps>(
   component: React.ComponentType<P>
 ): void {
@@ -67,7 +70,7 @@ export default function registerRootComponent<P extends InitialProps>(
     if (process.env.EXPO_PUBLIC_USE_STATIC) {
       hydrateRoot(tag, React.createElement(qualifiedComponent));
     } else {
-      const rootTag = createRoot(tag);
+      rootTag ??= createRoot(tag);
       rootTag.render(React.createElement(qualifiedComponent));
     }
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3251,10 +3251,10 @@
   dependencies:
     "@babel/runtime" "^7.13.10"
 
-"@radix-ui/react-slot@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@radix-ui/react-slot/-/react-slot-1.0.0.tgz#7fa805b99891dea1e862d8f8fbe07f4d6d0fd698"
-  integrity sha512-3mrKauI/tWXo1Ll+gN5dHcxDPdm/Df1ufcDLCecn+pnCIVcdWE7CujXo8QaXOWRJyZyQWWbpB8eFwHzWXlv5mQ==
+"@radix-ui/react-slot@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-slot/-/react-slot-1.0.1.tgz#e7868c669c974d649070e9ecbec0b367ee0b4d81"
+  integrity sha512-avutXAFL1ehGvAXtPquu0YK5oz6ctS474iM3vNGQIkswrVhdrS52e3uoMQBzZhNRAIE0jBnUyXWNmSjGHhCFcw==
   dependencies:
     "@babel/runtime" "^7.13.10"
     "@radix-ui/react-compose-refs" "1.0.0"
@@ -11666,7 +11666,7 @@ metro-file-map@0.76.3:
   optionalDependencies:
     fsevents "^2.3.2"
 
-metro-hermes-compiler@0.76.3:
+metro-hermes-compiler@0.76.0:
   version "0.76.0"
   resolved "https://registry.yarnpkg.com/metro-hermes-compiler/-/metro-hermes-compiler-0.76.0.tgz#2c4cca498011cab799434527544c0303eb12b806"
   integrity sha512-ZW1jHtErMp327aPEkhHP69dLmtbzGj7ajsNFEwayoz/tZtyrTXT+f/8j6QVynIBMMpnAJkSIlinNo9fgIbE08w==


### PR DESCRIPTION
# Motivation

This is part of a longer list of web-related refresh issues. Changing the context module when using SPA-styled rendering, will assert that the root node should be reused.
