### PR TITLE
fix adding a missing route when async routes is enabled 

### DIFF
--- a/packages/expo-router/src/useScreens.tsx
+++ b/packages/expo-router/src/useScreens.tsx
@@ -118,6 +118,15 @@ function fromImport({ ErrorBoundary, ...component }: LoadedRoute) {
       }),
     };
   }
+  if (process.env.NODE_ENV !== "production") {
+    if (
+      typeof component.default === "object" &&
+      component.default &&
+      Object.keys(component.default).length === 0
+    ) {
+      return { default: EmptyRoute };
+    }
+  }
   return { default: component.default || EmptyRoute };
 }
 


### PR DESCRIPTION
# Motivation

Currently the default export is coming back as an empty object, this was not originally the case. We now need to check if the object is not a function to ensure we have a correct fallback for missing screens.
