### PR TITLE
fix(router): fix create entry when run outside of monorepos

### DIFF
--- a/packages/expo-router/src/matchers.tsx
+++ b/packages/expo-router/src/matchers.tsx
@@ -35,7 +35,7 @@ export function removeSupportedExtensions(name: string): string {
 }
 
 // Remove any amount of `./` and `../` from the start of the string
-function removeFileSystemDots(filePath: string): string {
+export function removeFileSystemDots(filePath: string): string {
   return filePath.replace(/^(?:\.\.?\/)+/g, "");
 }
 

--- a/packages/expo-router/src/onboard/Tutorial.tsx
+++ b/packages/expo-router/src/onboard/Tutorial.tsx
@@ -79,7 +79,7 @@ export function Tutorial() {
 }
 
 function getRootDir() {
-  const dir = process.env.EXPO_ROUTER_APP_ROOT!;
+  const dir = process.env.EXPO_ROUTER_ABS_APP_ROOT!;
   if (dir.match(/\/src\/app$/)) {
     return "src/app";
   } else if (dir.match(/\/app$/)) {

--- a/packages/expo-router/src/onboard/__tests__/createEntryFile.test.node.ts
+++ b/packages/expo-router/src/onboard/__tests__/createEntryFile.test.node.ts
@@ -9,6 +9,6 @@ it(`returns correct absolute path for standard projects`, () => {
   expect(getAbsolutePath()).toEqual("/path/to/expo/project/app/index.js");
 });
 it(`returns correct absolute path for standard projects with src dir`, () => {
-  process.env.EXPO_PROJECT_ROOT = "/path/to/expo/project/src/app";
+  process.env.EXPO_ROUTER_ABS_APP_ROOT = "/path/to/expo/project/src/app";
   expect(getAbsolutePath()).toEqual("/path/to/expo/project/src/app/index.js");
 });

--- a/packages/expo-router/src/onboard/__tests__/createEntryFile.test.node.ts
+++ b/packages/expo-router/src/onboard/__tests__/createEntryFile.test.node.ts
@@ -1,0 +1,14 @@
+import { getAbsolutePath } from "../createEntryFile";
+
+beforeEach(() => {
+  delete process.env.EXPO_ROUTER_ABS_APP_ROOT;
+});
+
+it(`returns correct absolute path for standard projects`, () => {
+  process.env.EXPO_ROUTER_ABS_APP_ROOT = "/path/to/expo/project/app";
+  expect(getAbsolutePath()).toEqual("/path/to/expo/project/app/index.js");
+});
+it(`returns correct absolute path for standard projects with src dir`, () => {
+  process.env.EXPO_PROJECT_ROOT = "/path/to/expo/project/src/app";
+  expect(getAbsolutePath()).toEqual("/path/to/expo/project/src/app/index.js");
+});

--- a/packages/expo-router/src/onboard/createEntryFile.ts
+++ b/packages/expo-router/src/onboard/createEntryFile.ts
@@ -1,4 +1,5 @@
 import { getDevServer } from "../getDevServer";
+import { removeFileSystemDots } from "../matchers";
 
 /** Middleware for creating an entry file in the project. */
 export function createEntryFileAsync() {
@@ -19,7 +20,7 @@ export function createEntryFileAsync() {
       absolutePath:
         process.env.EXPO_PROJECT_ROOT +
         "/" +
-        process.env.EXPO_ROUTER_APP_ROOT +
+        removeFileSystemDots(process.env.EXPO_ROUTER_APP_ROOT!) +
         "/" +
         "./index.js",
     }),

--- a/packages/expo-router/src/onboard/createEntryFile.ts
+++ b/packages/expo-router/src/onboard/createEntryFile.ts
@@ -1,5 +1,4 @@
 import { getDevServer } from "../getDevServer";
-import { removeFileSystemDots } from "../matchers";
 
 /** Middleware for creating an entry file in the project. */
 export function createEntryFileAsync() {
@@ -17,14 +16,13 @@ export function createEntryFileAsync() {
       // Legacy
       path: "./app/index.js",
       // New
-      absolutePath:
-        process.env.EXPO_PROJECT_ROOT +
-        "/" +
-        removeFileSystemDots(process.env.EXPO_ROUTER_APP_ROOT!) +
-        "/" +
-        "./index.js",
+      absolutePath: getAbsolutePath(),
     }),
   });
+}
+
+export function getAbsolutePath() {
+  return process.env.EXPO_ROUTER_ABS_APP_ROOT + "/index.js";
 }
 
 const TEMPLATE = `import { StyleSheet, Text, View } from "react-native";


### PR DESCRIPTION
# Motivation

The current resolution did not work outside of monorepos. Added a new more solid environment variable and added some basic tests.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# Execution

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
