### PR TITLE
feat: allow +html file to use hooks

### DIFF
--- a/apps/tester/html-hooks/+html.js
+++ b/apps/tester/html-hooks/+html.js
@@ -1,0 +1,21 @@
+import { usePathname } from "expo-router";
+import { ScrollViewStyleReset } from "expo-router/html";
+
+export default function Root({ children }) {
+  const pathname = usePathname();
+  return (
+    <html lang="en">
+      <head>
+        <meta charSet="utf-8" />
+        <meta httpEquiv="X-UA-Compatible" content="IE=edge" />
+        <meta name="custom-value" content={pathname} />
+        <meta
+          name="viewport"
+          content="width=device-width,initial-scale=1,minimum-scale=1,maximum-scale=1.00001,viewport-fit=cover"
+        />
+        <ScrollViewStyleReset />
+      </head>
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/apps/tester/html-hooks/index.js
+++ b/apps/tester/html-hooks/index.js
@@ -1,0 +1,5 @@
+import { Text } from "react-native";
+
+export default function Page() {
+  return <Text>Index</Text>;
+}

--- a/apps/tester/html-hooks/test.js
+++ b/apps/tester/html-hooks/test.js
@@ -1,0 +1,5 @@
+import { Text } from "react-native";
+
+export default function Page() {
+  return <Text>Index</Text>;
+}

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "metro-react-native-babel-preset": "0.76.3",
     "ws": "7.5.9",
     "@expo/cli": "file:./expo-cli-29032023.tgz",
-    "@typescript-eslint/typescript-estree": "^5.59.1"
+    "@typescript-eslint/typescript-estree": "^5.59.1",
+    "react-refresh": "^0.14.0"
   },
   "devDependencies": {
     "@testing-library/jest-native": "^5.4.2",

--- a/packages/expo-router/_entry.tsx
+++ b/packages/expo-router/_entry.tsx
@@ -6,13 +6,14 @@ import React from "react";
 
 import { ctx } from "./_ctx";
 import { ExpoRoot } from "./src";
+import { ExpoRootProps } from "./src/ExpoRoot";
 import { getNavigationConfig } from "./src/getLinkingConfig";
 import { getRoutes } from "./src/getRoutes";
 import { loadStaticParamsAsync } from "./src/loadStaticParamsAsync";
 
 // Must be exported or Fast Refresh won't update the context >:[
-export default function ExpoRouterRoot({ location }: { location: URL }) {
-  return <ExpoRoot context={ctx} location={location} />;
+export default function ExpoRouterRoot(props: Omit<ExpoRootProps, "context">) {
+  return <ExpoRoot context={ctx} {...props} />;
 }
 
 /** Get the linking manifest from a Node.js process. */

--- a/packages/expo-router/src/global-state/router-store.tsx
+++ b/packages/expo-router/src/global-state/router-store.tsx
@@ -61,6 +61,7 @@ export class RouterStore {
     this.storeSubscribers.clear();
 
     this.routeNode = getRoutes(context);
+
     this.rootComponent = this.routeNode
       ? getQualifiedRouteComponent(this.routeNode)
       : Fragment;

--- a/packages/expo-router/src/static/renderStaticContent.tsx
+++ b/packages/expo-router/src/static/renderStaticContent.tsx
@@ -16,17 +16,6 @@ import { getRootComponent } from "./getRootComponent";
 
 AppRegistry.registerComponent("App", () => App);
 
-function resetReactNavigationContexts() {
-  // https://github.com/expo/router/discussions/588
-  // https://github.com/react-navigation/react-navigation/blob/9fe34b445fcb86e5666f61e144007d7540f014fa/packages/elements/src/getNamedContext.tsx#LL3C1-L4C1
-
-  // React Navigation is storing providers in a global, this is fine for the first static render
-  // but subsequent static renders of Stack or Tabs will cause React to throw a warning. To prevent this warning, we'll reset the globals before rendering.
-  const contexts = "__react_navigation__elements_contexts";
-  // @ts-expect-error: global
-  global[contexts] = new Map<string, React.Context<any>>();
-}
-
 export function getStaticContent(location: URL): string {
   const headContext: { helmet?: any } = {};
 
@@ -40,19 +29,6 @@ export function getStaticContent(location: URL): string {
   } = AppRegistry.getApplication("App");
 
   const Root = getRootComponent();
-
-  // const out = React.createElement(Root, {
-  //   // TODO: Use RNW view after they fix hydration for React 18
-  //   // https://github.com/necolas/react-native-web/blob/e8098fd029102d7801c32c1ede792bce01808c00/packages/react-native-web/src/exports/render/index.js#L10
-  //   // Otherwise this wraps the app with two extra divs
-  //   children:
-  //     // Inject the root tag using createElement to prevent any transforms like the ones in `@expo/html-elements`.
-  //     ,
-  // });
-
-  // This MUST be run before `ReactDOMServer.renderToString` to prevent
-  // "Warning: Detected multiple renderers concurrently rendering the same context provider. This is currently unsupported."
-  resetReactNavigationContexts();
 
   const html = ReactDOMServer.renderToString(
     <Head.Provider context={headContext}>

--- a/packages/expo-router/src/static/renderStaticContent.tsx
+++ b/packages/expo-router/src/static/renderStaticContent.tsx
@@ -41,20 +41,14 @@ export function getStaticContent(location: URL): string {
 
   const Root = getRootComponent();
 
-  const out = React.createElement(Root, {
-    // TODO: Use RNW view after they fix hydration for React 18
-    // https://github.com/necolas/react-native-web/blob/e8098fd029102d7801c32c1ede792bce01808c00/packages/react-native-web/src/exports/render/index.js#L10
-    // Otherwise this wraps the app with two extra divs
-    children:
-      // Inject the root tag using createElement to prevent any transforms like the ones in `@expo/html-elements`.
-      React.createElement(
-        "div",
-        {
-          id: "root",
-        },
-        <App location={location} />
-      ),
-  });
+  // const out = React.createElement(Root, {
+  //   // TODO: Use RNW view after they fix hydration for React 18
+  //   // https://github.com/necolas/react-native-web/blob/e8098fd029102d7801c32c1ede792bce01808c00/packages/react-native-web/src/exports/render/index.js#L10
+  //   // Otherwise this wraps the app with two extra divs
+  //   children:
+  //     // Inject the root tag using createElement to prevent any transforms like the ones in `@expo/html-elements`.
+  //     ,
+  // });
 
   // This MUST be run before `ReactDOMServer.renderToString` to prevent
   // "Warning: Detected multiple renderers concurrently rendering the same context provider. This is currently unsupported."
@@ -62,7 +56,22 @@ export function getStaticContent(location: URL): string {
 
   const html = ReactDOMServer.renderToString(
     <Head.Provider context={headContext}>
-      <ServerContainer ref={ref}>{out}</ServerContainer>
+      <ServerContainer ref={ref}>
+        <App
+          location={location}
+          wrapper={({ children }) => {
+            return React.createElement(Root, {
+              children: React.createElement(
+                "div",
+                {
+                  id: "root",
+                },
+                children
+              ),
+            });
+          }}
+        />
+      </ServerContainer>
     </Head.Provider>
   );
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -14322,10 +14322,10 @@ react-native@0.71.6:
     whatwg-fetch "^3.0.0"
     ws "^6.2.2"
 
-react-refresh@^0.4.0:
-  version "0.4.3"
-  resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.4.3.tgz#966f1750c191672e76e16c2efa569150cc73ab53"
-  integrity sha512-Hwln1VNuGl/6bVwnd0Xdn1e84gT/8T9aYNL+HAKDArLCS7LWjwr7StE30IEYbIkx0Vi3vs+coQxe+SQDbGbbpA==
+react-refresh@^0.14.0, react-refresh@^0.4.0:
+  version "0.14.0"
+  resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.14.0.tgz#4e02825378a5f227079554d4284889354e5f553e"
+  integrity sha512-wViHqhAd8OHeLS/IRMJjTSDHF3U9eWi62F/MledQGPdJGDhodXJ9PBLNGr6WWL7qlH12Mt3TyTpbS+hGXMjCzQ==
 
 react-shallow-renderer@^16.15.0:
   version "16.15.0"


### PR DESCRIPTION
Adds an extra `wrapper` prop to `<ExpoRoot />` that allows for the render routes to be wrapped in a parent component that is within the navigation context. For static rendering, this means the `+html` file is simply a wrapper component and can now use hooks.

This context could also be reused for tests and other scenarios.

An interesting side effect it seems like we can remove the React Navigation context hack. I'm assuming that because we are now always rendering within a Provider?

