### PR TITLE
fix(metro-runtime): fix position for error overlays

### DIFF
--- a/packages/expo-metro-runtime/src/error-overlay/ErrorOverlay.tsx
+++ b/packages/expo-metro-runtime/src/error-overlay/ErrorOverlay.tsx
@@ -5,8 +5,9 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
+import { StyleSheet } from "@bacons/react-views";
 import React, { useCallback, useEffect, useState } from "react";
-import { Keyboard, ScrollView, StyleSheet, View } from "react-native";
+import { Keyboard, ScrollView, View } from "react-native";
 
 import * as LogBoxData from "./Data/LogBoxData";
 import { LogBoxLog, StackType } from "./Data/LogBoxLog";
@@ -108,7 +109,7 @@ export function LogBoxInspector({
   );
 
   return (
-    <View style={[StyleSheet.absoluteFill, { flex: 1 }]}>
+    <View style={styles.container}>
       <ErrorOverlayHeader
         onSelectIndex={onChangeSelectedIndex}
         level={log.level}
@@ -183,6 +184,15 @@ const styles = StyleSheet.create({
   scrollBody: {
     backgroundColor: LogBoxStyle.getBackgroundColor(1),
     flex: 1,
+  },
+  container: {
+    top: 0,
+    left: 0,
+    bottom: 0,
+    right: 0,
+    zIndex: 999,
+    flex: 1,
+    position: "fixed",
   },
 });
 

--- a/packages/expo-router/src/views/Toast.tsx
+++ b/packages/expo-router/src/views/Toast.tsx
@@ -80,7 +80,7 @@ const styles = StyleSheet.create({
     borderWidth: 1,
     borderColor: "rgba(255,255,255,0.2)",
     flexDirection: "row",
-    position: "absolute",
+    position: "fixed",
     bottom: 8,
     left: 8,
     paddingVertical: 8,


### PR DESCRIPTION
# Motivation

Ensure error overlays are fixed to the screen to handle cases where body scrolling is enabled.
