### PR TITLE
feat: deprecate <Screen /> redirect prop

### DIFF
--- a/packages/expo-router/src/hooks.ts
+++ b/packages/expo-router/src/hooks.ts
@@ -11,6 +11,7 @@ import {
   useStoreRouteInfo,
 } from "./global-state/router-store";
 import { Router } from "./types";
+import { useDeprecated } from "./useDeprecated";
 
 type SearchParams = Record<string, string | string[]>;
 
@@ -28,7 +29,7 @@ export function useRootNavigation() {
 
 // Wraps useLinkTo to provide an API which is similar to the Link component.
 export function useLink() {
-  console.warn("`useLink()` is deprecated in favor of `useRouter()`");
+  useDeprecated("`useLink()` is deprecated in favor of `useRouter()`");
   return useRouter();
 }
 

--- a/packages/expo-router/src/useDeprecated.ts
+++ b/packages/expo-router/src/useDeprecated.ts
@@ -1,0 +1,35 @@
+import { useLayoutEffect } from "react";
+import { Platform } from "react-native";
+
+// Node environment may render in multiple processes causing the warning to log mutiple times
+// Hence we skip the warning in these environments.
+const canWarn = Platform.select({
+  native: process.env.NODE_ENV !== "production",
+  default:
+    process.env.NODE_ENV !== "production" && typeof window !== "undefined",
+});
+
+const warned = new Set<string>();
+
+export function useWarnOnce(
+  message: string,
+  guard: unknown = true,
+  key = message
+) {
+  // useLayoutEffect typically doesn't run in node environments.
+  // Combined with skipWarn, this should prevent unwanted warnings
+  useLayoutEffect(() => {
+    if (guard && canWarn && !warned.has(key)) {
+      warned.add(key);
+      console.warn(message);
+    }
+  }, [guard]);
+}
+
+export function useDeprecated(
+  message: string,
+  guard: unknown = true,
+  key = message
+) {
+  return useWarnOnce(key, guard, `Expo Router: ${message}`);
+}

--- a/packages/expo-router/src/views/Screen.tsx
+++ b/packages/expo-router/src/views/Screen.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 
+import { useDeprecated } from "../useDeprecated";
 import { useNavigation } from "../useNavigation";
 
 export type ScreenProps<
@@ -35,6 +36,11 @@ export function Screen<TOptions extends object = object>({
   useLayoutEffect(() => {
     navigation.setOptions(options ?? {});
   }, [navigation, options]);
+
+  useDeprecated(
+    "The `redirect` prop on <Screen /> is deprecated and will be removed. Please use `router.redirect` instead",
+    redirect
+  );
 
   if (process.env.NODE_ENV !== "production") {
     // eslint-disable-next-line react-hooks/rules-of-hooks

--- a/packages/expo-router/src/views/Screen.tsx
+++ b/packages/expo-router/src/views/Screen.tsx
@@ -37,10 +37,13 @@ export function Screen<TOptions extends object = object>({
     navigation.setOptions(options ?? {});
   }, [navigation, options]);
 
-  useDeprecated(
-    "The `redirect` prop on <Screen /> is deprecated and will be removed. Please use `router.redirect` instead",
-    redirect
-  );
+  if (process.env.NODE_ENV === "development") {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    useDeprecated(
+      "The `redirect` prop on <Screen /> is deprecated and will be removed. Please use `router.redirect` instead",
+      redirect
+    );
+  }
 
   if (process.env.NODE_ENV !== "production") {
     // eslint-disable-next-line react-hooks/rules-of-hooks

--- a/packages/expo-router/src/views/Splash.tsx
+++ b/packages/expo-router/src/views/Splash.tsx
@@ -1,6 +1,7 @@
 import * as SplashModule from "expo-splash-screen";
 import { nanoid } from "nanoid/non-secure";
 import * as React from "react";
+import { Platform } from "react-native";
 
 import { useDeprecated } from "../useDeprecated";
 

--- a/packages/expo-router/src/views/Splash.tsx
+++ b/packages/expo-router/src/views/Splash.tsx
@@ -1,7 +1,8 @@
 import * as SplashModule from "expo-splash-screen";
 import { nanoid } from "nanoid/non-secure";
 import * as React from "react";
-import { Platform } from "react-native";
+
+import { useDeprecated } from "../useDeprecated";
 
 const globalStack: string[] = [];
 
@@ -25,11 +26,9 @@ const globalStack: string[] = [];
  */
 export function SplashScreen() {
   useGlobalSplash();
-  React.useEffect(() => {
-    console.warn(
-      "The <SplashScreen /> component is deprecated. Use `SplashScreen.preventAutoHideAsync()` and `SplashScreen.hideAsync` from `expo-router` instead."
-    );
-  }, []);
+  useDeprecated(
+    "The <SplashScreen /> component is deprecated. Use `SplashScreen.preventAutoHideAsync()` and `SplashScreen.hideAsync` from `expo-router` instead."
+  );
   return null;
 }
 


### PR DESCRIPTION
# Motivation

ENG-8666

# Execution

We have a couple of existing deprecation warnings, so I cleaned up the code-base so they use the same logic. This also prevents the warning during SSR so it won't spam your CI console when static rendering
