### PR TITLE
chore: manifest is deprecated in SDK 49, use expoConfig instead

### DIFF
--- a/packages/expo-head/src/url.tsx
+++ b/packages/expo-head/src/url.tsx
@@ -44,11 +44,9 @@ const memoSanitizeUrl = memoize(sanitizeUrl);
 
 function getUrlFromConstants(): string | null {
   // This will require a rebuild in bare-workflow to update.
-  const manifest =
-    Constants.expoConfig || Constants.manifest2 || Constants.manifest;
+  const manifest = Constants.expoConfig;
 
   const origin =
-    // @ts-expect-error
     manifest?.extra?.router?.headOrigin ?? manifest?.extra?.router?.origin;
 
   if (!origin) {

--- a/packages/expo-metro-runtime/src/location/install.native.ts
+++ b/packages/expo-metro-runtime/src/location/install.native.ts
@@ -9,9 +9,7 @@ import { install, setLocationHref } from "./Location";
 
 let hasWarned = false;
 
-const manifest = (Constants.manifest ??
-  Constants.manifest2 ??
-  Constants.expoConfig) as Record<string, any> | null;
+const manifest = Constants.expoConfig as Record<string, any> | null;
 
 // Add a development warning for fetch requests with relative paths
 // to ensure developers are aware of the need to configure a production


### PR DESCRIPTION
# Motivation

SDK 49 will warn when you read from manifest. `expoConfig` is included in older SDKs and should work well as a replacement for this use case.

# Execution

Made the change. Tried running tests locally but was unable to get the repo setup.

# Test Plan

Made the change directly in node_modules, worked as expected and no warning