### PR TITLE
router v2 rc fixes

### DIFF
--- a/apps/demo/package.json
+++ b/apps/demo/package.json
@@ -16,7 +16,7 @@
     "expo": "^48.0.0",
     "expo-auth-session": "~4.0.3",
     "expo-random": "~13.1.1",
-    "expo-router": "*",
+    "expo-router": "2.0.0-rc.1",
     "expo-secure-store": "~12.1.1",
     "react": "18.2.0",
     "react-dom": "18.2.0",

--- a/apps/sandbox/package.json
+++ b/apps/sandbox/package.json
@@ -15,7 +15,7 @@
     "expo": "~48.0.10",
     "expo-auth-session": "~4.0.3",
     "expo-random": "~13.1.1",
-    "expo-router": "*",
+    "expo-router": "2.0.0-rc.1",
     "expo-secure-store": "~12.1.1",
     "react": "18.2.0",
     "react-dom": "18.2.0",

--- a/apps/tester/package.json
+++ b/apps/tester/package.json
@@ -15,7 +15,7 @@
     "expo": "^48.0.0",
     "expo-auth-session": "~4.0.3",
     "expo-random": "~13.1.1",
-    "expo-router": "*",
+    "expo-router": "2.0.0-rc.1",
     "expo-secure-store": "~12.1.1",
     "react": "18.2.0",
     "react-dom": "18.2.0",

--- a/packages/expo-head/package.json
+++ b/packages/expo-head/package.json
@@ -26,7 +26,6 @@
   "peerDependencies": {
     "expo": "*",
     "expo-constants": "*",
-    "expo-router": "*",
     "react": "*",
     "react-native": "*"
   }

--- a/packages/expo-head/src/ExpoHead.ios.tsx
+++ b/packages/expo-head/src/ExpoHead.ios.tsx
@@ -1,10 +1,10 @@
 import { useIsFocused } from "@react-navigation/core";
 import {
   useLocalSearchParams,
-  // @ts-ignore: TODO -- extract these into a shared library to prevent cyclic dependencies
   useUnstableGlobalHref,
   usePathname,
   useSegments,
+  // @ts-ignore: hack
 } from "expo-router";
 import React from "react";
 

--- a/packages/expo-router/babel.js
+++ b/packages/expo-router/babel.js
@@ -59,7 +59,7 @@ function getExpoRouterImportMode(projectRoot, platform) {
   }
 
   // NOTE: This is a temporary workaround for static rendering on web.
-  if (platform === "web" && process.env.EXPO_USE_STATIC) {
+  if (platform === "web" && (exp.web || {}).output === "static") {
     mode = "sync";
   }
 

--- a/packages/expo-router/plugin/options.json
+++ b/packages/expo-router/plugin/options.json
@@ -67,7 +67,6 @@
                     ]
                 }
             },
-            "required": ["origin"],
             "additionalProperties": false
         }
     }

--- a/packages/expo-router/plugin/src/index.ts
+++ b/packages/expo-router/plugin/src/index.ts
@@ -21,7 +21,7 @@ const withExpoHeadIos: ConfigPlugin = (config) => {
 
 const withRouter: ConfigPlugin<{
   /** Production origin URL where assets in the public folder are hosted. The fetch function is polyfilled to support relative requests from this origin in production, development origin is inferred using the Expo CLI development server. */
-  origin: string;
+  origin?: string;
   /** A more specific origin URL used in the `expo-router/head` module for iOS handoff. Defaults to `origin`. */
   headOrigin?: string;
   /** Changes the routes directory from `app` to another value. Defaults to `app`. Avoid using this property. */
@@ -40,6 +40,7 @@ const withRouter: ConfigPlugin<{
     extra: {
       ...config.extra,
       router: {
+        origin: false,
         ...config.extra?.router,
         ...props,
       },

--- a/packages/expo-router/src/ExpoRoot.tsx
+++ b/packages/expo-router/src/ExpoRoot.tsx
@@ -19,6 +19,10 @@ function getGestureHandlerRootView() {
     const { GestureHandlerRootView } =
       require("react-native-gesture-handler") as typeof import("react-native-gesture-handler");
 
+    if (!GestureHandlerRootView) {
+      return React.Fragment;
+    }
+
     // eslint-disable-next-line no-inner-declarations
     function GestureHandler(props: any) {
       return <GestureHandlerRootView style={{ flex: 1 }} {...props} />;


### PR DESCRIPTION
# Motivation

- fix static rendering with async routes
- fix react-native-gesture-handler being uninstalled in RN 72
- default `origin` to false (this will need to be reverted).

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# Execution

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
