### PR TITLE
fix(router): expect more optionals

### DIFF
--- a/packages/expo-router/src/Route.tsx
+++ b/packages/expo-router/src/Route.tsx
@@ -7,7 +7,7 @@ export type DynamicConvention = { name: string; deep: boolean };
 
 export type LoadedRoute = {
   ErrorBoundary?: React.ComponentType<ErrorBoundaryProps>;
-  default: React.ComponentType<any>;
+  default?: React.ComponentType<any>;
   unstable_settings?: Record<string, any>;
   getNavOptions?: (args: any) => any;
   generateStaticParams?: (props: {
@@ -17,7 +17,7 @@ export type LoadedRoute = {
 
 export type RouteNode = {
   /** Load a route into memory. Returns the exports from a route. */
-  loadRoute: () => LoadedRoute;
+  loadRoute: () => Partial<LoadedRoute>;
   /** Loaded initial route name. */
   initialRouteName?: string;
   /** nested routes */

--- a/packages/expo-router/src/getRoutes.ts
+++ b/packages/expo-router/src/getRoutes.ts
@@ -149,7 +149,7 @@ function applyDefaultInitialRouteName(node: RouteNode): RouteNode {
     : undefined;
   const loaded = node.loadRoute();
 
-  if (loaded.unstable_settings) {
+  if (loaded?.unstable_settings) {
     // Allow unstable_settings={ initialRouteName: '...' } to override the default initial route name.
     initialRouteName =
       loaded.unstable_settings.initialRouteName ?? initialRouteName;

--- a/packages/expo-router/src/useScreens.tsx
+++ b/packages/expo-router/src/useScreens.tsx
@@ -110,7 +110,7 @@ function fromImport({ ErrorBoundary, ...component }: LoadedRoute) {
   if (ErrorBoundary) {
     return {
       default: React.forwardRef((props: any, ref: any) => {
-        const children = React.createElement(component.default, {
+        const children = React.createElement(component.default || EmptyRoute, {
           ...props,
           ref,
         });


### PR DESCRIPTION
# Motivation

@brentvatne reported a related error without a repro. This is a guess at a potential fix where we assume that empty routes can get through somehow.
