### PR TITLE
fix(router): add hasUrlProtocolPrefix

### DIFF
--- a/packages/expo-router/src/global-state/routing.ts
+++ b/packages/expo-router/src/global-state/routing.ts
@@ -15,6 +15,7 @@ import {
   getQualifiedStateForTopOfTargetState,
   isMovingToSiblingRoute,
 } from "../link/stateOperations";
+import { hasUrlProtocolPrefix } from "../utils/url";
 import type { RouterStore } from "./router-store";
 
 function assertIsReady(store: RouterStore) {
@@ -45,7 +46,7 @@ export function setParams(
 }
 
 export function linkTo(this: RouterStore, href: string, event?: string) {
-  if (isRemoteHref(href)) {
+  if (hasUrlProtocolPrefix(href)) {
     Linking.openURL(href);
     return;
   }
@@ -158,10 +159,6 @@ export function linkTo(this: RouterStore, href: string, event?: string) {
   } else {
     navigationRef.reset(state);
   }
-}
-
-function isRemoteHref(href: string): boolean {
-  return /:\/\//.test(href);
 }
 
 /** @returns `true` if the action is moving to the first screen of all the navigators in the action. */

--- a/packages/expo-router/src/utils/__tests__/url.test.node.ts
+++ b/packages/expo-router/src/utils/__tests__/url.test.node.ts
@@ -1,0 +1,27 @@
+import { hasUrlProtocolPrefix } from "../url";
+
+describe(hasUrlProtocolPrefix, () => {
+  [
+    "",
+    "hello",
+    "about?uri=https://localhost:8081",
+    "https%3A%2F%2Flocalhost%3A8081%3Fabout%3Dface",
+  ].forEach((href) => {
+    it(`should return false for "${href}"`, () => {
+      expect(hasUrlProtocolPrefix(href)).toBe(false);
+    });
+  });
+  [
+    "http://",
+    "https://",
+    "mailto://",
+    "tel://",
+    "sms://",
+    "exp+com.my-app_thing://",
+    "hello://world.com",
+  ].forEach((href) => {
+    it(`should return true for "${href}"`, () => {
+      expect(hasUrlProtocolPrefix(href)).toBe(true);
+    });
+  });
+});

--- a/packages/expo-router/src/utils/url.ts
+++ b/packages/expo-router/src/utils/url.ts
@@ -1,0 +1,7 @@
+/**
+ * Does the input string start with a valid URL scheme.
+ * NOTE: Additional strictness added to ensure URLs sent in query parameters for in-app navigation are not matched.
+ */
+export function hasUrlProtocolPrefix(href: string): boolean {
+  return /^[\w\d_+.-]+:\/\//.test(href);
+}


### PR DESCRIPTION
# Motivation

Add additional strictness added to ensure URLs sent in query parameters for in-app navigation are not matched.
