### PR TITLE
fix(router): disable setting the document.title with React Navigation

### DIFF
--- a/packages/expo-router/src/ExpoRoot.tsx
+++ b/packages/expo-router/src/ExpoRoot.tsx
@@ -104,6 +104,9 @@ function ContextNavigator({
       ref={store.navigationRef}
       initialState={store.initialState}
       linking={store.linking}
+      documentTitle={{
+        enabled: false,
+      }}
     >
       <WrapperComponent>
         <Component />


### PR DESCRIPTION
# Motivation

The title should be set by `expo-router/head`, the React Navigation handle breaks assumptions about how head works.
