### PR TITLE
fix(router): strip hashes before navigating

### DIFF
--- a/packages/expo-router/src/__tests__/globalState.test.node.tsx
+++ b/packages/expo-router/src/__tests__/globalState.test.node.tsx
@@ -100,7 +100,6 @@ describe(RouterStore, () => {
       rootState: {
         routes: [
           {
-            _route: undefined,
             name: "index",
             path: "/",
           },
@@ -109,7 +108,6 @@ describe(RouterStore, () => {
       initialState: {
         routes: [
           {
-            _route: undefined,
             name: "index",
             path: "/",
           },

--- a/packages/expo-router/src/__tests__/navigation.test.tsx
+++ b/packages/expo-router/src/__tests__/navigation.test.tsx
@@ -86,6 +86,25 @@ describe("imperative only", () => {
 
     expect(await screen.findByText("test-name")).toBeOnTheScreen();
   });
+  it("can handle navigation between routes with hashes", async () => {
+    renderRouter({
+      index: function MyIndexRoute() {
+        return <Text testID="index">Press me</Text>;
+      },
+      "/profile/[name]": function MyRoute() {
+        const { name } = useGlobalSearchParams();
+        return <Text>{name}</Text>;
+      },
+    });
+
+    await screen.findByTestId("index");
+
+    act(() => {
+      router.push("/profile/test-name?foo=bar#baz");
+    });
+
+    expect(await screen.findByText("test-name")).toBeOnTheScreen();
+  });
 });
 
 describe("mixed navigation", () => {

--- a/packages/expo-router/src/fork/__tests__/getStateFromPath.test.node.ts
+++ b/packages/expo-router/src/fork/__tests__/getStateFromPath.test.node.ts
@@ -1,5 +1,74 @@
 import { configFromFs } from "../../utils/mockState";
-import getStateFromPath from "../getStateFromPath";
+import getStateFromPath, {
+  getUrlWithReactNavigationConcessions,
+} from "../getStateFromPath";
+
+describe(getUrlWithReactNavigationConcessions, () => {
+  ["/", "foo/", "foo/bar/", "foo/bar/baz/"].forEach((path) => {
+    it(`returns the pathname for ${path}`, () => {
+      expect(
+        getUrlWithReactNavigationConcessions(path).nonstandardPathname
+      ).toBe(path);
+    });
+  });
+
+  [
+    ["", "/"],
+    ["https://acme.com/hello/world?foo=bar#123", "hello/world/"],
+    ["https://acme.com/hello/world/?foo=bar#123", "hello/world/"],
+  ].forEach(([url, expected]) => {
+    it(`returns the pathname for ${url}`, () => {
+      expect(
+        getUrlWithReactNavigationConcessions(url).nonstandardPathname
+      ).toBe(expected);
+    });
+  });
+  [
+    ["", ""],
+    [
+      "https://acme.com/hello/world/?foo=bar#123",
+      "https://acme.com/hello/world/?foo=bar",
+    ],
+    ["/foobar#123", "/foobar"],
+  ].forEach(([url, expected]) => {
+    it(`returns the pathname without hash for ${url}`, () => {
+      expect(
+        getUrlWithReactNavigationConcessions(url).inputPathnameWithoutHash
+      ).toBe(expected);
+    });
+  });
+});
+
+it(`strips hashes`, () => {
+  expect(
+    getStateFromPath("/hello#123", {
+      screens: {
+        hello: "hello",
+      },
+    } as any)
+  ).toEqual({
+    routes: [
+      {
+        name: "hello",
+        path: "/hello",
+      },
+    ],
+  });
+
+  expect(getStateFromPath("/hello#123", configFromFs(["[hello].js"]))).toEqual({
+    routes: [
+      {
+        name: "[hello]",
+        params: {
+          hello: "hello",
+        },
+        path: "/hello",
+      },
+    ],
+  });
+
+  // TODO: Test rest params
+});
 
 it(`supports spaces`, () => {
   expect(

--- a/packages/expo-router/src/fork/getStateFromPath.ts
+++ b/packages/expo-router/src/fork/getStateFromPath.ts
@@ -6,6 +6,7 @@ import type {
 } from "@react-navigation/routers";
 import escape from "escape-string-regexp";
 import * as queryString from "query-string";
+import URL from "url-parse";
 
 import { RouteNode } from "../Route";
 import { matchGroupName, stripGroupSegmentsFromPath } from "../matchers";
@@ -47,14 +48,18 @@ type ParsedRoute = {
   params?: Record<string, any> | undefined;
 };
 
-function getPathname(path: string) {
-  const remaining = path
-    .replace(/\/+/g, "/") // Replace multiple slash (//) with single ones
-    .replace(/^\//, "") // Remove extra leading slash
-    .replace(/\?.*$/, ""); // Remove query params which we will handle later
+export function getUrlWithReactNavigationConcessions(path: string) {
+  const parsed = new URL(path, "https://acme.com");
+  const pathname = parsed.pathname;
 
   // Make sure there is a trailing slash
-  return remaining.endsWith("/") ? remaining : `${remaining}/`;
+  return {
+    // The slashes are at the end, not the beginning
+    nonstandardPathname:
+      pathname.replace(/^\/+/g, "").replace(/\/+$/g, "") + "/",
+    // React Navigation doesn't support hashes, so here
+    inputPathnameWithoutHash: path.replace(/#.*$/, ""),
+  };
 }
 
 /**
@@ -316,10 +321,15 @@ function getStateFromEmptyPathWithConfigs(
     return undefined;
   }
 
-  const routes = match.routeNames.map((name) => ({
-    name,
-    _route: match._route,
-  }));
+  const routes = match.routeNames.map((name) => {
+    if (!match._route) {
+      return { name };
+    }
+    return {
+      name,
+      _route: match._route,
+    };
+  });
 
   return createNestedStateObject(path, routes, configs, initialRoutes);
 }
@@ -329,21 +339,33 @@ function getStateFromPathWithConfigs(
   configs: RouteConfig[],
   initialRoutes: InitialRouteConfig[]
 ): ResultState | undefined {
-  const pathname = getPathname(path);
+  const formattedPaths = getUrlWithReactNavigationConcessions(path);
 
-  if (pathname === "/") {
-    return getStateFromEmptyPathWithConfigs(path, configs, initialRoutes);
+  if (formattedPaths.nonstandardPathname === "/") {
+    return getStateFromEmptyPathWithConfigs(
+      formattedPaths.inputPathnameWithoutHash,
+      configs,
+      initialRoutes
+    );
   }
 
   // We match the whole path against the regex instead of segments
   // This makes sure matches such as wildcard will catch any unmatched routes, even if nested
-  const routes = matchAgainstConfigs(pathname, configs);
+  const routes = matchAgainstConfigs(
+    formattedPaths.nonstandardPathname,
+    configs
+  );
 
   if (routes == null) {
     return undefined;
   }
   // This will always be empty if full path matched
-  return createNestedStateObject(path, routes, configs, initialRoutes);
+  return createNestedStateObject(
+    formattedPaths.inputPathnameWithoutHash,
+    routes,
+    configs,
+    initialRoutes
+  );
 }
 
 const joinPaths = (...paths: string[]): string =>
@@ -424,10 +446,15 @@ function matchAgainstConfigs(
       return { name };
     };
 
-    routes = config.routeNames.map((name) => ({
-      ...routeFromName(name),
-      _route: config._route,
-    }));
+    routes = config.routeNames.map((name) => {
+      if (!config._route) {
+        return { ...routeFromName(name) };
+      }
+      return {
+        ...routeFromName(name),
+        _route: config._route,
+      };
+    });
 
     // TODO(EvanBacon): Maybe we should warn / assert if multiple slugs use the same param name.
     const combinedParams = routes.reduce<Record<string, any>>(


### PR DESCRIPTION
# Motivation

Not exactly hash support, but it does prevent hashes from breaking Expo Router. We can circle back and expose the hash segment another time.

# How

- Ensure hashes are stripped before attempting to parse state from path.

# Test Plan

- Added new tests for basic state, the stripping function, and a smoke test.