### PR TITLE
refactor: remove duplicate `sortRoutes` declaration

### DIFF
--- a/packages/expo-router/src/global-state/sort-routes.ts
+++ b/packages/expo-router/src/global-state/sort-routes.ts
@@ -1,5 +1,4 @@
-import { RouteNode } from "../Route";
-import { matchGroupName } from "../matchers";
+import { sortRoutes } from "../Route";
 import type { RouterStore } from "./router-store";
 
 export function getSortedRoutes(this: RouterStore) {
@@ -9,40 +8,5 @@ export function getSortedRoutes(this: RouterStore) {
 
   return this.routeNode.children
     .filter((route) => !route.internal)
-    .sort((a: RouteNode, b: RouteNode): number => {
-      if (a.dynamic && !b.dynamic) {
-        return 1;
-      }
-      if (!a.dynamic && b.dynamic) {
-        return -1;
-      }
-      if (a.dynamic && b.dynamic) {
-        if (a.dynamic.length !== b.dynamic.length) {
-          return b.dynamic.length - a.dynamic.length;
-        }
-        for (let i = 0; i < a.dynamic.length; i++) {
-          const aDynamic = a.dynamic[i];
-          const bDynamic = b.dynamic[i];
-          if (aDynamic.deep && !bDynamic.deep) {
-            return 1;
-          }
-          if (!aDynamic.deep && bDynamic.deep) {
-            return -1;
-          }
-        }
-        return 0;
-      }
-
-      const aIndex = a.route === "index" || matchGroupName(a.route) != null;
-      const bIndex = b.route === "index" || matchGroupName(b.route) != null;
-
-      if (aIndex && !bIndex) {
-        return -1;
-      }
-      if (!aIndex && bIndex) {
-        return 1;
-      }
-
-      return a.route.length - b.route.length;
-    });
+    .sort(sortRoutes);
 }


### PR DESCRIPTION
# Motivation

We can use the already tested and declared `sortRoutes` function.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

CI should be fine.
