### PR TITLE
chore(router): set sdk 49 compatible splash screen version explicitly

### DIFF
--- a/packages/expo-router/package.json
+++ b/packages/expo-router/package.json
@@ -110,7 +110,7 @@
     "@react-navigation/native": "~6.1.6",
     "@react-navigation/native-stack": "~6.9.12",
     "expo-head": "0.0.11",
-    "expo-splash-screen": "*",
+    "expo-splash-screen": "~0.20.2",
     "query-string": "7.1.3",
     "react-helmet-async": "^1.3.0",
     "schema-utils": "^4.0.1",


### PR DESCRIPTION
# Motivation

`expo-router` is now tied to SDK versions via **bundledNativeModules.json**, so let's align the splash version with SDK 49. Ideally, we'd have an optional peer dependency on `expo-splash-screen` and use conditional imports in our code for this, but support for optional imports is not currently very reliable/stable in Metro.

# Execution

Update version

# Test Plan

Install this in an SDK 49 project, no more warnings when running `npx expo-doctor@latest`
