### PR TITLE
[docs] Update Expo Router advanced section links

### DIFF
--- a/docs/docs/guides/header-buttons.md
+++ b/docs/docs/guides/header-buttons.md
@@ -5,6 +5,6 @@ sidebar_position: 6
 
 :::note Migration
 
-This guide has [moved to the Expo Docs](https://docs.expo.dev/router/advance/stack/#header-buttons).
+This guide has [moved to the Expo Docs](https://docs.expo.dev/router/advanced/stack/#header-buttons).
 
 :::

--- a/docs/docs/guides/headers.md
+++ b/docs/docs/guides/headers.md
@@ -5,6 +5,6 @@ sidebar_position: 5
 
 :::note Migration
 
-This guide has [moved to the Expo Docs](https://docs.expo.dev/router/advance/stack/).
+This guide has [moved to the Expo Docs](https://docs.expo.dev/router/advanced/stack/).
 
 :::

--- a/docs/docs/guides/modals.md
+++ b/docs/docs/guides/modals.md
@@ -4,6 +4,6 @@ title: Modals
 
 :::note Migration
 
-This guide has [moved to the Expo Docs](https://docs.expo.dev/router/advance/modal/).
+This guide has [moved to the Expo Docs](https://docs.expo.dev/router/advanced/modals/).
 
 :::

--- a/docs/docs/guides/nesting-navigators.md
+++ b/docs/docs/guides/nesting-navigators.md
@@ -5,6 +5,6 @@ sidebar_position: 7
 
 :::note Migration
 
-This guide has [moved to the Expo Docs](https://docs.expo.dev/router/advance/nesting-navigators/).
+This guide has [moved to the Expo Docs](https://docs.expo.dev/router/advanced/nesting-navigators/).
 
 :::

--- a/docs/docs/guides/platform-specific-code.md
+++ b/docs/docs/guides/platform-specific-code.md
@@ -4,6 +4,6 @@ title: Platform Specific Code
 
 :::note Migration
 
-This guide has [moved to the Expo Docs](https://docs.expo.dev/router/advance/platform-specific-modules/).
+This guide has [moved to the Expo Docs](https://docs.expo.dev/router/advanced/platform-specific-modules/).
 
 :::

--- a/docs/docs/guides/root-layout.md
+++ b/docs/docs/guides/root-layout.md
@@ -4,6 +4,6 @@ title: Root Layout
 
 :::note Migration
 
-This guide has [moved to the Expo Docs](https://docs.expo.dev/router/advance/root-layout/).
+This guide has [moved to the Expo Docs](https://docs.expo.dev/router/advanced/root-layout/).
 
 :::

--- a/docs/docs/guides/tabs.md
+++ b/docs/docs/guides/tabs.md
@@ -4,6 +4,6 @@ title: Tabs
 
 :::note Migration
 
-This guide has [moved to the Expo Docs](https://docs.expo.dev/router/advance/tabs/).
+This guide has [moved to the Expo Docs](https://docs.expo.dev/router/advanced/tabs/).
 
 :::


### PR DESCRIPTION
# Motivation

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Follow up PR for https://github.com/expo/expo/pull/23313

# Execution

<!--
How did you build this feature or fix this bug and why?
-->

Fix all `advance` references in URL paths to `advanced`.
