### PR TITLE
[update/router-demo] expo sdk version updated from "expo": "^48.0.0" to "expo": "~49.0.0" 

### DIFF
--- a/apps/demo/package.json
+++ b/apps/demo/package.json
@@ -13,7 +13,7 @@
     "@babel/plugin-proposal-export-namespace-from": "^7.18.9",
     "@react-native-async-storage/async-storage": "~1.17.3",
     "@react-navigation/drawer": "^6.4.4",
-    "expo": "^48.0.0",
+    "expo": "~49.0.0",
     "expo-auth-session": "~4.0.3",
     "expo-random": "~13.1.1",
     "expo-router": "2.0.0",


### PR DESCRIPTION
Updated package.json "expo": "^48.0.0" to "expo": "~49.0.0"

# Motivation

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->
I believe this to be a possible be oversight and easily fixable via PR if so

[Link to opened issue](https://github.com/expo/router/issues/742)