### PR TITLE
feat(ios): view controller based status bar appearance

### DIFF
--- a/packages/expo-router/src/ExpoRoot.tsx
+++ b/packages/expo-router/src/ExpoRoot.tsx
@@ -1,3 +1,4 @@
+import Constants from "expo-constants";
 import { StatusBar } from "expo-status-bar";
 import React, { FunctionComponent, ReactNode, Fragment } from "react";
 import { Platform } from "react-native";
@@ -44,6 +45,11 @@ const INITIAL_METRICS = {
   insets: { top: 0, left: 0, right: 0, bottom: 0 },
 };
 
+const hasViewControllerBasedStatusBarAppearance =
+  Platform.OS === "ios" &&
+  !!Constants.expoConfig?.ios?.infoPlist
+    ?.UIViewControllerBasedStatusBarAppearance;
+
 export function ExpoRoot({
   wrapper: ParentWrapper = Fragment,
   ...props
@@ -64,7 +70,9 @@ export function ExpoRoot({
             {children}
 
             {/* Users can override this by adding another StatusBar element anywhere higher in the component tree. */}
-            <StatusBar style="auto" />
+            {!hasViewControllerBasedStatusBarAppearance && (
+              <StatusBar style="auto" />
+            )}
           </SafeAreaProvider>
         </GestureHandlerRootView>
       </ParentWrapper>


### PR DESCRIPTION
# Motivation
Fixes: https://github.com/expo/router/issues/772
Background info: https://github.com/software-mansion/react-native-screens/issues/1305

Currently the status bar transitions upon closing (swiping down) a native modal on iOS are delayed.
To allow smooth status bar transitions you need to set the following in app.json:
```
"infoPlist": {
  "UIViewControllerBasedStatusBarAppearance": true
},
```

This requires that there are no `<StatusBar />` components being rendered in your app as this leads to the following crash: _RCTStatusBarManager module requires that the UIViewControllerBasedStatusBarAppearance key in the Info.plist is set to NO_.

Solution: This PR makes sure that no `<StatusBar />` component will be rendered on iOS if the user enabled UIViewControllerBasedStatusBarAppearance.

<img src="https://github.com/expo/router/assets/12894112/b0472868-6c1c-4136-b424-59c24e45bd88" width="320" />
