### PR TITLE
fix infinite loop when using invalid initialRouteName

### DIFF
--- a/packages/expo-router/src/__tests__/navigation.test.tsx
+++ b/packages/expo-router/src/__tests__/navigation.test.tsx
@@ -239,3 +239,29 @@ it("pushes auto-encoded params and fully qualified URLs", () => {
     three: "one,two,three",
   });
 });
+
+it("does not loop infinitely when pushing a screen with empty options to an invalid initial route name", () => {
+  /** https://github.com/expo/router/issues/452 */
+
+  renderRouter({
+    _layout: () => <Stack />,
+    index: () => <Text />,
+    "main/_layout": {
+      unstable_settings: {
+        // NOTE(EvanBacon): This has to be an invalid route.
+        initialRouteName: "index",
+      },
+      default: () => <Stack />,
+    },
+    "main/welcome": () => (
+      <>
+        <Stack.Screen options={{}} />
+        <Text />
+      </>
+    ),
+  });
+
+  expect(screen).toHavePathname("/");
+  act(() => router.push("/main/welcome"));
+  expect(screen).toHavePathname("/main/welcome");
+});

--- a/packages/expo-router/src/views/Screen.tsx
+++ b/packages/expo-router/src/views/Screen.tsx
@@ -33,7 +33,14 @@ export function Screen<TOptions extends object = object>({
   const navigation = useNavigation(name);
 
   useLayoutEffect(() => {
-    navigation.setOptions(options ?? {});
+    if (
+      options &&
+      // React Navigation will infinitely loop in some cases if an empty object is passed to setOptions.
+      // https://github.com/expo/router/issues/452
+      Object.keys(options).length
+    ) {
+      navigation.setOptions(options);
+    }
   }, [navigation, options]);
 
   if (process.env.NODE_ENV !== "production") {


### PR DESCRIPTION
# Motivation

- fix https://github.com/expo/router/issues/452
