### PR TITLE
fix initial route modal being presented instantly

### DIFF
--- a/packages/expo-router/src/global-state/router-store.tsx
+++ b/packages/expo-router/src/global-state/router-store.tsx
@@ -118,7 +118,11 @@ export class RouterStore {
       (data) => {
         const state = data.data.state as ResultState;
 
-        if (navigationRef.isReady()) {
+        if (
+          navigationRef.isReady() ||
+          // NOTE(EvanBacon): `navigationRef.isReady` is sometimes not true when state is called initially.
+          !this.isReady
+        ) {
           this.onReady();
         }
 

--- a/packages/expo-router/src/global-state/router-store.tsx
+++ b/packages/expo-router/src/global-state/router-store.tsx
@@ -188,9 +188,6 @@ export class RouterStore {
 
   /** Make sure these are arrow functions so `this` is correctly bound */
   onReady = () => {
-    // if (!this.isReady) {
-    //   requestAnimationFrame(() => _internal_maybeHideAsync());
-    // }
     this.isReady = true;
   };
   subscribeToRootState = (subscriber: () => void) => {


### PR DESCRIPTION
# Motivation

- While playing with authentication redirects, I found a case where the splash screen wasn't being hidden correctly.
- Couldn't replicate with the test suite so I just left a note.

# Execution

- Hide the splash screen as soon as navigation events start coming in, rather than waiting for the navigation state to be "ready". This is presumably a bug in React Navigation that we are working around.
- Users can still prevent hiding by adding the preventAutoHide line outside of a component.
<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

```
app/
  _layout.js -> Stack (initialRouteName=index) -> Instantly push `/modal`
  modal.js -> Modal
  index.js
```

- Modal should push and the splash should hide in the background.

