### PR TITLE
fix(router): allow nullish params

### DIFF
--- a/packages/expo-router/src/link/__tests__/href.test.node.ts
+++ b/packages/expo-router/src/link/__tests__/href.test.node.ts
@@ -31,6 +31,17 @@ describe(resolveHref, () => {
       })
     ).toBe("/alpha/cool/beta");
   });
+  it(`allows nullish query parameters`, () => {
+    expect(resolveHref({ pathname: "/alpha", params: { beta: null } })).toBe(
+      "/alpha"
+    );
+    expect(
+      resolveHref({
+        pathname: "/alpha",
+        params: { beta: undefined, three: "1" },
+      })
+    ).toBe("/alpha?three=1");
+  });
   it(`adds query parameters`, () => {
     expect(resolveHref({ pathname: "/alpha", params: { beta: "value" } })).toBe(
       "/alpha?beta=value"

--- a/packages/expo-router/src/link/href.ts
+++ b/packages/expo-router/src/link/href.ts
@@ -19,10 +19,8 @@ export const resolveHref = (href: Href): string => {
   const { pathname, params } = createQualifiedPathname(path, {
     ...href.params,
   });
-  return (
-    pathname +
-    (Object.keys(params).length ? `?${createQueryParams(params)}` : "")
-  );
+  const paramsString = createQueryParams(params);
+  return pathname + (paramsString ? `?${paramsString}` : "");
 };
 
 function createQualifiedPathname(
@@ -54,7 +52,11 @@ function encodeParam(param: any): string {
 }
 
 function createQueryParams(params: Record<string, any>): string {
-  return Object.entries(params)
-    .map(([key, value]) => `${key}=${encodeURIComponent(value.toString())}`)
-    .join("&");
+  return (
+    Object.entries(params)
+      // Allow nullish params
+      .filter(([, value]) => value != null)
+      .map(([key, value]) => `${key}=${encodeURIComponent(value.toString())}`)
+      .join("&")
+  );
 }


### PR DESCRIPTION
# Motivation

- allow nullish query parameters to be used in links.

# Test Plan

- Added tests