### PR TITLE
fix: remove store.onReady checks

### DIFF
--- a/packages/expo-router/src/global-state/router-store.tsx
+++ b/packages/expo-router/src/global-state/router-store.tsx
@@ -26,7 +26,6 @@ export class RouterStore {
   routeNode!: RouteNode | null;
   rootComponent!: ComponentType;
   linking: ExpoLinkingOptions | undefined;
-  isReady: boolean = false;
   private hasAttemptedToHideSplash: boolean = false;
 
   initialState: ResultState | undefined;
@@ -54,7 +53,6 @@ export class RouterStore {
     initialLocation?: URL
   ) {
     // Clean up any previous state
-    this.isReady ||= Boolean(initialLocation);
     this.initialState = undefined;
     this.rootState = undefined;
     this.nextState = undefined;
@@ -119,16 +117,10 @@ export class RouterStore {
       (data) => {
         const state = data.data.state as ResultState;
 
-        if (!this.isReady) {
-          if (!this.hasAttemptedToHideSplash) {
-            this.hasAttemptedToHideSplash = true;
-            // NOTE(EvanBacon): `navigationRef.isReady` is sometimes not true when state is called initially.
-            requestAnimationFrame(() => _internal_maybeHideAsync());
-          }
-
-          if (navigationRef.isReady()) {
-            this.onReady();
-          }
+        if (!this.hasAttemptedToHideSplash) {
+          this.hasAttemptedToHideSplash = true;
+          // NOTE(EvanBacon): `navigationRef.isReady` is sometimes not true when state is called initially.
+          requestAnimationFrame(() => _internal_maybeHideAsync());
         }
 
         let shouldUpdateSubscribers = this.nextState === state;
@@ -187,9 +179,6 @@ export class RouterStore {
   }
 
   /** Make sure these are arrow functions so `this` is correctly bound */
-  onReady = () => {
-    this.isReady = true;
-  };
   subscribeToRootState = (subscriber: () => void) => {
     this.rootStateSubscribers.add(subscriber);
     return () => this.rootStateSubscribers.delete(subscriber);

--- a/packages/expo-router/src/global-state/routing.ts
+++ b/packages/expo-router/src/global-state/routing.ts
@@ -19,7 +19,7 @@ import { hasUrlProtocolPrefix } from "../utils/url";
 import type { RouterStore } from "./router-store";
 
 function assertIsReady(store: RouterStore) {
-  if (!store.isReady || !store.navigationRef.current) {
+  if (!store.navigationRef.isReady()) {
     throw new Error(
       "Attempted to navigate before mounting the Root Layout component. Ensure the Root Layout component is rendering a Slot, or other navigator on the first render."
     );


### PR DESCRIPTION
# Motivation

Expo Router keeps a separate flag to check if React Navigation is ready. Unfortunately both `onReady` and `on('state')` fire after the initial `NavigationProvider` children have rendered, so if you perform navigation in a top-level `_layout` as a direct child (such as the `AuthProvider` in the example) you may get the error.

```
Error: Attempted to navigate before mounting the Root Layout component. Ensure the Root Layout component is rendering a Slot, or other navigator o
n the first render.
```

I think the best method is simply to remove the guard and rely on the RN `.isReady()` check.

# Test Plan

We cannot test this via our current test suite, as it runs Expo Router in the synchronise mode (same as static rendering). I need to investigate changing `renderRouter` so it is async.

You can manually test with the `AuthProvider` example
