### PR TITLE
Remove navigation context requirement for `canGoBack()`

### DIFF
--- a/packages/expo-router/src/global-state/routing.ts
+++ b/packages/expo-router/src/global-state/routing.ts
@@ -40,7 +40,6 @@ export function goBack(this: RouterStore) {
 }
 
 export function canGoBack(this: RouterStore): boolean {
-  assertIsReady(this);
   return this.navigationRef?.current?.canGoBack() ?? false;
 }
 


### PR DESCRIPTION
# Motivation

Our application runs a lot of async logic on app start before rendering the routing tree. During this time we had a utility function to wrap the `router.back` API in which we did the following:

```
const useNavigation = () => {
  const router = useRouter();

  return {
    navigate: router.push,
    back: router.canGoBack() ? router.back : () => router.push('/')
  };
}
```

Unexpectedly, the function call to `canGoBack()` was throwing an assertion about trying to navigate without the navigation context.

# Execution

I changed the code via the github UI with zero testing or validation. 🙃 

# Test Plan

Please advise how I can best support and test this
