### PR TITLE
fix(ENG-9886):  deprecated false positive

### DIFF
--- a/packages/expo-router/src/useDeprecated.ts
+++ b/packages/expo-router/src/useDeprecated.ts
@@ -17,7 +17,7 @@ export function useWarnOnce(
   key = message
 ) {
   // useLayoutEffect typically doesn't run in node environments.
-  // Combined with skipWarn, this should prevent unwanted warnings
+  // Combined with skipWarn, this should prevent unwanted warnings during SSR rendering
   useLayoutEffect(() => {
     if (guard && canWarn && !warned.has(key)) {
       warned.add(key);
@@ -27,8 +27,11 @@ export function useWarnOnce(
 }
 
 export function useDeprecated(
+  /** The deprecated message to display */
   message: string,
+  /** The guard to cause the warning to being displayed */
   guard: unknown = true,
+  /** The key to use for the warning. Used to detect if the warning has already been shown. */
   key = message
 ) {
   return useWarnOnce(key, guard, `Expo Router: ${message}`);

--- a/packages/expo-router/src/views/Screen.tsx
+++ b/packages/expo-router/src/views/Screen.tsx
@@ -48,7 +48,7 @@ export function Screen<TOptions extends object = object>({
     // eslint-disable-next-line react-hooks/rules-of-hooks
     useDeprecated(
       "The `redirect` prop on <Screen /> is deprecated and will be removed. Please use `router.redirect` instead",
-      redirect
+      Boolean(redirect)
     );
   }
 


### PR DESCRIPTION
# Motivation

Fix ENG-9886.

# Execution

`useDeprecated` is a hook I added a while ago to easily log deprecated warnings once, and handle edge cases such as preventing multiple warnings during SSR & CI environment. I added code comments to explain its parameters.

The issue was the `guard` has a default value of `true`. So if you pass `undefined`, instead of using `undefined` it will switch to `true`. This is counter intuitive and a sign this hook needs to be refactored.

I like the guard having a truthy default, because you can simply write `useDeprecated(<message>)` with no guard. Maybe we need to split it into two functions?

```tsx
useDeprecated(<message>, <key>)
useDeprecatedWithGuard(<message>, <guard>, <key>)
```
