### PR TITLE
add listener types

### DIFF
--- a/packages/expo-router/src/layouts/Drawer.tsx
+++ b/packages/expo-router/src/layouts/Drawer.tsx
@@ -1,7 +1,9 @@
 import {
   createDrawerNavigator,
+  DrawerNavigationEventMap,
   DrawerNavigationOptions,
 } from "@react-navigation/drawer";
+import { DrawerNavigationState, ParamListBase } from "@react-navigation/native";
 
 import { withLayoutContext } from "./withLayoutContext";
 
@@ -9,7 +11,9 @@ const DrawerNavigator = createDrawerNavigator().Navigator;
 
 export const Drawer = withLayoutContext<
   DrawerNavigationOptions,
-  typeof DrawerNavigator
+  typeof DrawerNavigator,
+  DrawerNavigationState<ParamListBase>,
+  DrawerNavigationEventMap
 >(DrawerNavigator);
 
 export default Drawer;

--- a/packages/expo-router/src/layouts/Stack.tsx
+++ b/packages/expo-router/src/layouts/Stack.tsx
@@ -1,9 +1,9 @@
+import { ParamListBase, StackNavigationState } from "@react-navigation/native";
 import {
   createNativeStackNavigator,
   NativeStackNavigationEventMap,
   NativeStackNavigationOptions,
 } from "@react-navigation/native-stack";
-import { ParamListBase, StackNavigationState } from "@react-navigation/native";
 
 import { withLayoutContext } from "./withLayoutContext";
 

--- a/packages/expo-router/src/layouts/Stack.tsx
+++ b/packages/expo-router/src/layouts/Stack.tsx
@@ -1,7 +1,9 @@
 import {
   createNativeStackNavigator,
+  NativeStackNavigationEventMap,
   NativeStackNavigationOptions,
 } from "@react-navigation/native-stack";
+import { ParamListBase, StackNavigationState } from "@react-navigation/native";
 
 import { withLayoutContext } from "./withLayoutContext";
 
@@ -9,7 +11,9 @@ const NativeStackNavigator = createNativeStackNavigator().Navigator;
 
 export const Stack = withLayoutContext<
   NativeStackNavigationOptions,
-  typeof NativeStackNavigator
+  typeof NativeStackNavigator,
+  StackNavigationState<ParamListBase>,
+  NativeStackNavigationEventMap
 >(NativeStackNavigator);
 
 export default Stack;

--- a/packages/expo-router/src/layouts/Tabs.tsx
+++ b/packages/expo-router/src/layouts/Tabs.tsx
@@ -1,8 +1,10 @@
 import { Pressable } from "@bacons/react-views";
 import {
   BottomTabNavigationOptions,
+  BottomTabNavigationEventMap,
   createBottomTabNavigator,
 } from "@react-navigation/bottom-tabs";
+import { TabNavigationState, ParamListBase } from "@react-navigation/native";
 import React from "react";
 import { Platform } from "react-native";
 
@@ -15,7 +17,9 @@ const BottomTabNavigator = createBottomTabNavigator().Navigator;
 
 export const Tabs = withLayoutContext<
   BottomTabNavigationOptions & { href?: Href | null },
-  typeof BottomTabNavigator
+  typeof BottomTabNavigator,
+  TabNavigationState<ParamListBase>,
+  BottomTabNavigationEventMap
 >(BottomTabNavigator, (screens) => {
   // Support the `href` shortcut prop.
   return screens.map((screen) => {

--- a/packages/expo-router/src/layouts/withLayoutContext.tsx
+++ b/packages/expo-router/src/layouts/withLayoutContext.tsx
@@ -1,5 +1,5 @@
-import React from "react";
 import { EventMapBase, NavigationState } from "@react-navigation/native";
+import React from "react";
 
 import { useContextKey } from "../Route";
 import { PickPartial } from "../types";

--- a/packages/expo-router/src/layouts/withLayoutContext.tsx
+++ b/packages/expo-router/src/layouts/withLayoutContext.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { EventMapBase, NavigationState } from "@react-navigation/native";
 
 import { useContextKey } from "../Route";
 import { PickPartial } from "../types";
@@ -67,15 +68,19 @@ export function useFilterScreenChildren(
 /** Return a navigator that automatically injects matched routes and renders nothing when there are no children. Return type with children prop optional */
 export function withLayoutContext<
   TOptions extends object,
-  T extends React.ComponentType<any>
+  T extends React.ComponentType<any>,
+  State extends NavigationState,
+  EventMap extends EventMapBase
 >(
   Nav: T,
-  processor?: (options: ScreenProps<TOptions>[]) => ScreenProps<TOptions>[]
+  processor?: (
+    options: ScreenProps<TOptions, State, EventMap>[]
+  ) => ScreenProps<TOptions, State, EventMap>[]
 ): React.ForwardRefExoticComponent<
   React.PropsWithoutRef<PickPartial<React.ComponentProps<T>, "children">> &
     React.RefAttributes<unknown>
 > & {
-  Screen: (props: ScreenProps<TOptions>) => null;
+  Screen: (props: ScreenProps<TOptions, State, EventMap>) => null;
 } {
   const Navigator = React.forwardRef(
     (

--- a/packages/expo-router/src/useScreens.tsx
+++ b/packages/expo-router/src/useScreens.tsx
@@ -1,4 +1,11 @@
 import React from "react";
+import type {
+  EventMapBase,
+  NavigationState,
+  ParamListBase,
+  RouteProp,
+  ScreenListeners,
+} from "@react-navigation/native";
 
 import {
   DynamicConvention,
@@ -15,7 +22,9 @@ import { SuspenseFallback } from "./views/SuspenseFallback";
 import { Try } from "./views/Try";
 
 export type ScreenProps<
-  TOptions extends Record<string, any> = Record<string, any>
+  TOptions extends Record<string, any> = Record<string, any>,
+  State extends NavigationState = NavigationState,
+  EventMap extends EventMapBase = EventMapBase
 > = {
   /** Name is required when used inside a Layout component. */
   name?: string;
@@ -27,8 +36,12 @@ export type ScreenProps<
   initialParams?: { [key: string]: any };
   options?: TOptions;
 
-  // TODO: types
-  listeners?: any;
+  listeners?:
+    | ScreenListeners<State, EventMap>
+    | ((prop: {
+        route: RouteProp<ParamListBase, string>;
+        navigation: any;
+      }) => ScreenListeners<State, EventMap>);
 
   getId?: ({
     params,

--- a/packages/expo-router/src/useScreens.tsx
+++ b/packages/expo-router/src/useScreens.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import type {
   EventMapBase,
   NavigationState,
@@ -6,6 +5,7 @@ import type {
   RouteProp,
   ScreenListeners,
 } from "@react-navigation/native";
+import React from "react";
 
 import {
   DynamicConvention,


### PR DESCRIPTION
# Motivation
FIX #860 

# Execution
The types were already exported from `@react-navigation`, I used `withLayoutContext` with generics to add those types in  `Stack`, `Tabs` and `Drawer` navigation

# Test Plan
This pull request can be tested by checking the types of listener prop in any navigator in one of the sandbox projects in app directory
