### PR TITLE
fix erroneous redirect warning

### DIFF
--- a/packages/expo-router/src/views/Screen.tsx
+++ b/packages/expo-router/src/views/Screen.tsx
@@ -44,7 +44,7 @@ export function Screen<TOptions extends object = object>({
     }
   }, [navigation, options]);
 
-  if (process.env.NODE_ENV === "development") {
+  if (process.env.NODE_ENV === "development" && redirect != null) {
     // eslint-disable-next-line react-hooks/rules-of-hooks
     useDeprecated(
       "The `redirect` prop on <Screen /> is deprecated and will be removed. Please use `router.redirect` instead",


### PR DESCRIPTION
# Motivation

Redirect warnings for <Screen /> should only pop up if redirect is actually passed to the component.

# Execution

I fixed it because it was confusing users, and is not expected behavior.

# Test Plan

Compare this to expo-router without the fix, and note that the warning does not pop up simply by importing Screen from expo-router.
