### PR TITLE
[ROUTER/TABS] feat: Hide tabs by default option

### DIFF
--- a/packages/expo-router/src/layouts/Tabs.tsx
+++ b/packages/expo-router/src/layouts/Tabs.tsx
@@ -16,7 +16,7 @@ import { withLayoutContext } from "./withLayoutContext";
 const BottomTabNavigator = createBottomTabNavigator().Navigator;
 
 export const Tabs = withLayoutContext<
-  BottomTabNavigationOptions & { href?: Href | null },
+  BottomTabNavigationOptions & { href?: Href | null; hideTabsByDefault?: Boolean },
   typeof BottomTabNavigator,
   TabNavigationState<ParamListBase>,
   BottomTabNavigationEventMap

--- a/packages/expo-router/src/layouts/withLayoutContext.tsx
+++ b/packages/expo-router/src/layouts/withLayoutContext.tsx
@@ -86,6 +86,7 @@ export function withLayoutContext<
     (
       {
         children: userDefinedChildren,
+        hideTabsByDefault = false,
         ...props
       }: PickPartial<React.ComponentProps<T>, "children">,
       ref
@@ -98,7 +99,7 @@ export function withLayoutContext<
 
       const processed = processor ? processor(screens ?? []) : screens;
 
-      const sorted = useSortedScreens(processed ?? []);
+      const sorted = useSortedScreens(processed ?? [], { hideTabsByDefault });
 
       // Prevent throwing an error when there are no screens.
       if (!sorted.length) {

--- a/packages/expo-router/src/useScreens.tsx
+++ b/packages/expo-router/src/useScreens.tsx
@@ -116,11 +116,17 @@ function getSortedChildren(
 /**
  * @returns React Navigation screens sorted by the `route` property.
  */
-export function useSortedScreens(order: ScreenProps[]): React.ReactNode[] {
+export function useSortedScreens(order: ScreenProps[], {hideTabsByDefault = false} = {}): React.ReactNode[] {
   const node = useRouteNode();
 
   const sorted = node?.children?.length
-    ? getSortedChildren(node.children, order, node.initialRouteName)
+    ? getSortedChildren(
+      hideTabsByDefault
+        ? node?.children.filter(child => order.some(({name}) => child.route === name))
+        : node?.children,
+      order,
+      node.initialRouteName
+    )
     : [];
   return React.useMemo(
     () => sorted.map((value) => routeToScreen(value.route, value.props)),


### PR DESCRIPTION
# Motivation

It can be useful to only show the user-defined tabs in the tab-bar instead of showing all routes by default.

# Execution

This PR implements a `hideTabsByDefault` property that will ensure that the tab bar will only show the defined tabs instead of tabs for all routes

# Test Plan

TBA
