### PR TITLE
Change store.initailize execution hook from useMemo to useEffect and add test for useInitializeExpoRouter

### DIFF
--- a/packages/expo-router/src/ExpoRoot.tsx
+++ b/packages/expo-router/src/ExpoRoot.tsx
@@ -5,7 +5,7 @@ import { Platform } from "react-native";
 import { SafeAreaProvider } from "react-native-safe-area-context";
 
 import UpstreamNavigationContainer from "./fork/NavigationContainer";
-import { useInitializeExpoRouter } from "./global-state/router-store";
+import { useInitializeExpoRouter } from "./global-state/hooks";
 import { RequireContext } from "./types";
 import { SplashScreen } from "./views/Splash";
 

--- a/packages/expo-router/src/global-state/__tests__/router-store.test.tsx
+++ b/packages/expo-router/src/global-state/__tests__/router-store.test.tsx
@@ -1,0 +1,66 @@
+import { renderHook } from "../../../testing-library";
+import { RequireContext } from "../../types";
+import { useInitializeExpoRouter } from "../hooks";
+import { RouterStore, store as routerStore } from "../router-store";
+
+jest.mock("../router-store", () => ({
+  ...jest.requireActual("../router-store"),
+  store: {
+    ...jest.requireActual("../router-store").store,
+    initialize: jest.fn(),
+    subscribeToStore: jest.fn(),
+  },
+}));
+
+describe("useInitializeExpoRouter", () => {
+  let store: RouterStore;
+
+  const location = new URL("http://example.com");
+  const context: RequireContext = (id) => id;
+  context.keys = () => [1, 2, 3].map((s) => `${s}`);
+  context.resolve = () => "1";
+  context.id = "1";
+
+  beforeEach(async () => {
+    store = routerStore;
+    jest.clearAllMocks();
+  });
+
+  it("should call store.initialize when ref and context change", () => {
+    const { rerender } = renderHook(
+      (props) => useInitializeExpoRouter(...props),
+      { initialProps: [context, location] as const }
+    );
+
+    expect(store.initialize).toHaveBeenCalledWith(
+      context,
+      expect.anything(),
+      location
+    );
+    expect(store.subscribeToStore).toHaveBeenCalledTimes(1);
+
+    const newContext: RequireContext = (id) => id;
+    newContext.keys = () => [1, 2, 3].map((s) => `${s}_new`);
+    newContext.resolve = () => "2";
+    newContext.id = "2";
+    const newLocation = new URL("http://example.com/new");
+
+    rerender([newContext, newLocation]);
+    expect(store.initialize).toHaveBeenCalledWith(
+      newContext,
+      expect.anything(),
+      newLocation
+    );
+  });
+
+  it("should not call store.initialize when the same context is passed", () => {
+    const { rerender } = renderHook(
+      (props) => useInitializeExpoRouter(...props),
+      { initialProps: [context, location] as const }
+    );
+    expect(store.initialize).toHaveBeenCalledTimes(1);
+
+    rerender([context, location]);
+    expect(store.initialize).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/expo-router/src/global-state/hooks.tsx
+++ b/packages/expo-router/src/global-state/hooks.tsx
@@ -1,0 +1,58 @@
+import { useNavigationContainerRef } from "@react-navigation/native";
+import { useSyncExternalStore, useMemo } from "react";
+
+import { ResultState } from "../fork/getStateFromPath";
+import { RequireContext } from "../types";
+import { store } from "./router-store";
+
+export function useExpoRouter() {
+  return useSyncExternalStore(
+    store.subscribeToStore,
+    store.snapshot,
+    store.snapshot
+  );
+}
+
+function syncStoreRootState() {
+  if (store.navigationRef.isReady()) {
+    const currentState =
+      store.navigationRef.getRootState() as unknown as ResultState;
+
+    if (store.rootState !== currentState) {
+      store.updateState(currentState);
+    }
+  }
+}
+
+export function useStoreRootState() {
+  syncStoreRootState();
+  return useSyncExternalStore(
+    store.subscribeToRootState,
+    store.rootStateSnapshot,
+    store.rootStateSnapshot
+  );
+}
+
+export function useStoreRouteInfo() {
+  syncStoreRootState();
+  return useSyncExternalStore(
+    store.subscribeToRootState,
+    store.routeInfoSnapshot,
+    store.routeInfoSnapshot
+  );
+}
+
+export function useInitializeExpoRouter(
+  context: RequireContext,
+  initialLocation: URL | undefined
+) {
+  const navigationRef = useNavigationContainerRef();
+
+  useMemo(
+    () => store.initialize(context, navigationRef, initialLocation),
+    [context, initialLocation]
+  );
+
+  useExpoRouter();
+  return store;
+}

--- a/packages/expo-router/src/global-state/hooks.tsx
+++ b/packages/expo-router/src/global-state/hooks.tsx
@@ -1,5 +1,5 @@
 import { useNavigationContainerRef } from "@react-navigation/native";
-import { useSyncExternalStore, useMemo } from "react";
+import { useSyncExternalStore, useEffect } from "react";
 
 import { ResultState } from "../fork/getStateFromPath";
 import { RequireContext } from "../types";
@@ -48,7 +48,7 @@ export function useInitializeExpoRouter(
 ) {
   const navigationRef = useNavigationContainerRef();
 
-  useMemo(
+  useEffect(
     () => store.initialize(context, navigationRef, initialLocation),
     [context, initialLocation]
   );

--- a/packages/expo-router/src/global-state/router-store.ts
+++ b/packages/expo-router/src/global-state/router-store.ts
@@ -1,9 +1,8 @@
 import {
   NavigationContainerRefWithCurrent,
   getPathFromState,
-  useNavigationContainerRef,
 } from "@react-navigation/native";
-import { useSyncExternalStore, useMemo, ComponentType, Fragment } from "react";
+import { ComponentType, Fragment } from "react";
 
 import { UrlObject, getRouteInfoFromState } from "../LocationProvider";
 import { RouteNode } from "../Route";
@@ -199,53 +198,3 @@ export class RouterStore {
 }
 
 export const store = new RouterStore();
-
-export function useExpoRouter() {
-  return useSyncExternalStore(
-    store.subscribeToStore,
-    store.snapshot,
-    store.snapshot
-  );
-}
-
-function syncStoreRootState() {
-  if (store.navigationRef.isReady()) {
-    const currentState =
-      store.navigationRef.getRootState() as unknown as ResultState;
-
-    if (store.rootState !== currentState) {
-      store.updateState(currentState);
-    }
-  }
-}
-
-export function useStoreRootState() {
-  syncStoreRootState();
-  return useSyncExternalStore(
-    store.subscribeToRootState,
-    store.rootStateSnapshot,
-    store.rootStateSnapshot
-  );
-}
-
-export function useStoreRouteInfo() {
-  syncStoreRootState();
-  return useSyncExternalStore(
-    store.subscribeToRootState,
-    store.routeInfoSnapshot,
-    store.routeInfoSnapshot
-  );
-}
-
-export function useInitializeExpoRouter(
-  context: RequireContext,
-  initialLocation: URL | undefined
-) {
-  const navigationRef = useNavigationContainerRef();
-  useMemo(
-    () => store.initialize(context, navigationRef, initialLocation),
-    [context, initialLocation]
-  );
-  useExpoRouter();
-  return store;
-}

--- a/packages/expo-router/src/hooks.ts
+++ b/packages/expo-router/src/hooks.ts
@@ -5,11 +5,8 @@ import {
 } from "@react-navigation/native";
 import React from "react";
 
-import {
-  store,
-  useStoreRootState,
-  useStoreRouteInfo,
-} from "./global-state/router-store";
+import { useStoreRootState, useStoreRouteInfo } from "./global-state/hooks";
+import { store } from "./global-state/router-store";
 import { Router } from "./types";
 import { useDeprecated } from "./useDeprecated";
 

--- a/packages/expo-router/src/link/useLinkToPathProps.tsx
+++ b/packages/expo-router/src/link/useLinkToPathProps.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { GestureResponderEvent, Platform } from "react-native";
 
-import { useExpoRouter } from "../global-state/router-store";
+import { useExpoRouter } from "../global-state/hooks";
 import { stripGroupSegmentsFromPath } from "../matchers";
 
 function eventShouldPreventDefault(

--- a/packages/expo-router/src/link/useLoadedNavigation.ts
+++ b/packages/expo-router/src/link/useLoadedNavigation.ts
@@ -1,7 +1,7 @@
 import { NavigationProp, useNavigation } from "@react-navigation/native";
 import { useCallback, useState, useEffect, useRef } from "react";
 
-import { useExpoRouter } from "../global-state/router-store";
+import { useExpoRouter } from "../global-state/hooks";
 
 type GenericNavigation = NavigationProp<ReactNavigation.RootParamList>;
 

--- a/packages/expo-router/src/views/Sitemap.tsx
+++ b/packages/expo-router/src/views/Sitemap.tsx
@@ -10,7 +10,7 @@ import {
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 import { RouteNode } from "../Route";
-import { useExpoRouter } from "../global-state/router-store";
+import { useExpoRouter } from "../global-state/hooks";
 import { router } from "../imperative-api";
 import { Link } from "../link/Link";
 import { matchDeepDynamicRouteName } from "../matchers";


### PR DESCRIPTION
# Motivation

This PR proposes a modification in the interaction between the singleton "RouteStore" and React. Currently, the `useMemo` hook is being utilized, which is typically used for caching values ([useMemo documentation](https://react.dev/reference/react/useMemo)). This PR suggests that the `useEffect` hook might be more suitable for this context, as detailed in its [documentation](https://react.dev/reference/react/useEffect).


# Execution

To realize the proposed change, i undertook the following steps:

- Split the `global-state.tsx` file to facilitate the mocking of the store singleton, which was challenging with `jest.mock`.
- Modified `useMemo` to `useEffect` in `useInitializeExpoRouter` to ensure alignment with the proposed integration strategy.
- Conducted tests to verify the unchanged behavior of `useInitializeExpoRouter` post-modification.


# Test Plan

To substantiate these modifications, a comprehensive test plan has been devised. The testing strategy underscores:
- Validating that the `store.initialize` function is initiated exclusively when alterations occur in the context or location, reinforcing the stability and efficiency of the system.
- Confirming the precise invocation of the `useExpoRouter` function to maintain seamless connectivity and functionality.

The following strategies were employed during the testing phase:
1. The `store.initialize` function was monitored to ensure it is called when there is a change in reference and context, further validated by rerendering with new context and location values.
2. Observations were made to ascertain that the `store.initialize` function is not called repetitively when the same context is passed, fostering system efficiency.

These strategies were systematically executed using the `renderHook` function alongside the implementation of mock functions to mimic the behavior of the `store.initialize` and `store.subscribeToStore` methods, thereby offering a robust and reliable testing framework.
