### PR TITLE
Update new docs links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Expo Router
 
-The Expo Router repo **has moved** upstream to [**expo/expo**](https://github.com/expo/expo/). 
+The Expo Router repo **has moved** upstream to [**expo/expo**](https://github.com/expo/expo/).
 - [View the source code](https://github.com/expo/expo/tree/main/packages/expo-router).
-- [Read the docs](https://docs.expo.dev/routing/introduction/).
+- [Read the docs](https://docs.expo.dev/router/introduction/).
 - [Report an issue](https://github.com/expo/expo/issues/new?assignees=&labels=needs+validation%2CRouter&projects=&template=bug_report_router.yml).
 
 This repo will remain in maintenance-mode until Expo Router v3 is released.
@@ -21,7 +21,7 @@ The easiest way to try **Expo Router** is by creating a new project:
 npx create-expo-app@latest -e with-router
 ```
 
-See the [setup guide for more](https://docs.expo.dev/routing/installation/).
+See the [setup guide for more](https://docs.expo.dev/router/installation/).
 
 ## Examples
 

--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -7,7 +7,7 @@ slug: /
 
 :::note Migration
 
-This doc has [moved to the Expo Docs](https://docs.expo.dev/routing/introduction/).
+This doc has [moved to the Expo Docs](https://docs.expo.dev/router/introduction/).
 
 :::
 

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -76,7 +76,7 @@ const config = {
       announcementBar: {
         id: "v2-notice",
         content:
-          'Expo Router v2 and Expo SDK 49 are stable. The docs are moving to <a href="https://docs.expo.dev/routing/introduction/">docs.expo.dev</a>.',
+          'Expo Router v2 and Expo SDK 49 are stable. The docs are moving to <a href="https://docs.expo.dev/router/introduction/">docs.expo.dev</a>.',
         backgroundColor: "#fafbfc",
         textColor: "#091E42",
         isCloseable: true,


### PR DESCRIPTION
# Motivation

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

We recently organized Expo Router docs on docs.expo.dev and migrated them from Home to Guides so all docs live under one group. (PR in expo/expo: https://github.com/expo/expo/pull/25646)

This PR updates the older links which included `/routing/...` to the new URL path which includes `/router/...`.