### PR TITLE
fix(router): accept options function

### DIFF
--- a/packages/expo-router/src/useScreens.tsx
+++ b/packages/expo-router/src/useScreens.tsx
@@ -34,7 +34,10 @@ export type ScreenProps<
    */
   redirect?: boolean;
   initialParams?: { [key: string]: any };
-  options?: TOptions;
+  options?: TOptions | ((props: {
+    route: RouteProp<ParamListBase, string>;
+    navigation: any;
+  }) => ScreenOptions);
 
   listeners?:
     | ScreenListeners<State, EventMap>

--- a/packages/expo-router/src/useScreens.tsx
+++ b/packages/expo-router/src/useScreens.tsx
@@ -37,7 +37,7 @@ export type ScreenProps<
   options?: TOptions | ((props: {
     route: RouteProp<ParamListBase, string>;
     navigation: any;
-  }) => ScreenOptions);
+  }) => TOptions);
 
   listeners?:
     | ScreenListeners<State, EventMap>


### PR DESCRIPTION
Screen `options` prop is missing `function` type

# Motivation

TypeScript is currently prohibiting usage of `options` prop as a function, to configure options depending on `route` instance. Note that it's solely typing issue, the library itself supports it (see [useScreens.tsx](https://github.com/expo/router/blob/main/packages/expo-router/src/useScreens.tsx#L292))

# Execution

Adjusted type according to original `@react-navigation/core` [types](https://github.com/react-navigation/react-navigation/blob/5e297a05d7457336ef8f8d1bddaa486b5d8ab4e1/packages/core/src/types.tsx#L636)

# Test Plan

No tests required for this typing fix
